### PR TITLE
fix: gitignore containing files that should be version controlled when multiple plugins have the same outputs

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -24,6 +24,8 @@ export const CONFIG_DIRS = {
   subagents: "subagents",
 } as const;
 
+export const CROSS_TOOL_SKILLS_DIR = ".agents";
+
 export const TOOL_OUTPUT_DIRS: Record<ToolId, string> = {
   claudeCode: ".claude",
   opencode: ".opencode",

--- a/packages/core/src/plugins/codex/index.ts
+++ b/packages/core/src/plugins/codex/index.ts
@@ -1,4 +1,4 @@
-import { TOOL_OUTPUT_DIRS } from "../../constants";
+import { CROSS_TOOL_SKILLS_DIR, TOOL_OUTPUT_DIRS } from "../../constants";
 import type {
   McpServer,
   OutputFile,
@@ -18,7 +18,6 @@ import { groupRulesByDirectory } from "../../utils/rules";
 import type { Plugin } from "../types";
 
 const OUTPUT_DIR = TOOL_OUTPUT_DIRS.codex;
-const SKILLS_DIR = ".agents";
 
 /**
  * Codex plugin for exporting to .codex/ format
@@ -65,7 +64,7 @@ export const codexPlugin: Plugin = {
     }
 
     // Skills go to .agents/skills/ (cross-tool standard path)
-    files.push(...createSkillSymlinks(state, SKILLS_DIR));
+    files.push(...createSkillSymlinks(state, CROSS_TOOL_SKILLS_DIR));
 
     const configToml = buildCodexConfigToml(state.settings?.mcpServers);
     if (configToml) {

--- a/packages/core/src/plugins/opencode/index.ts
+++ b/packages/core/src/plugins/opencode/index.ts
@@ -1,4 +1,8 @@
-import { TOOL_OUTPUT_DIRS, UNIFIED_DIR } from "../../constants";
+import {
+  CROSS_TOOL_SKILLS_DIR,
+  TOOL_OUTPUT_DIRS,
+  UNIFIED_DIR,
+} from "../../constants";
 import type {
   OutputFile,
   UnifiedState,
@@ -19,7 +23,6 @@ import {
 } from "./transforms";
 
 const OUTPUT_DIR = TOOL_OUTPUT_DIRS.opencode;
-const SKILLS_DIR = ".agents";
 
 /**
  * OpenCode plugin for exporting to opencode.json format
@@ -60,7 +63,7 @@ export const opencodePlugin: Plugin = {
     }
 
     // Skills go to .agents/skills/ (cross-tool standard path)
-    files.push(...createSkillSymlinks(state, SKILLS_DIR));
+    files.push(...createSkillSymlinks(state, CROSS_TOOL_SKILLS_DIR));
 
     const config: Record<string, unknown> = {
       $schema: "https://opencode.ai/config.json",


### PR DESCRIPTION
Fix issue with gitignore containing files that should be version controlled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced .gitignore management: Shared AI-generated files are now intelligently included or excluded based on tool-specific version control settings. Files are only ignored when all producing tools have version control disabled, providing better control over tracked files.

* **Tests**
  * Added validation tests for gitignore behavior with mixed and unified version control configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->