### PR TITLE
fix(claude-code): write mcpServers to .mcp.json instead of settings.json

### DIFF
--- a/apps/docs/src/content/docs/tools/claude-code.md
+++ b/apps/docs/src/content/docs/tools/claude-code.md
@@ -14,8 +14,9 @@ LNAI exports unified configuration to Claude Code's native `.claude/` format.
 ├── CLAUDE.md          # Symlink → ../.ai/AGENTS.md
 ├── rules/             # Symlink → ../.ai/rules/
 ├── skills/<name>/     # Symlinks → ../../.ai/skills/<name>/
-├── settings.json      # Generated
+├── settings.json      # Generated (permissions)
 └── <overrides>        # Symlinks from .ai/.claude/
+.mcp.json              # Generated (mcpServers) at project root
 ```
 
 ## File Mapping
@@ -26,18 +27,30 @@ LNAI exports unified configuration to Claude Code's native `.claude/` format.
 | `.ai/rules/`         | `.claude/rules/`         | Symlink   |
 | `.ai/skills/<name>/` | `.claude/skills/<name>/` | Symlink   |
 | `.ai/settings.json`  | `.claude/settings.json`  | Generated |
+| `.ai/settings.json`  | `.mcp.json`              | Generated |
 | `.ai/.claude/<path>` | `.claude/<path>`         | Symlink   |
 
 ## Generated settings.json
 
-Settings are passed through directly in Claude format:
+Permissions are written to `.claude/settings.json`:
 
 ```json
 {
   "permissions": {
     "allow": ["Bash(git:*)"],
     "deny": ["Read(.env)"]
-  },
+  }
+}
+```
+
+To override the generated settings, place a custom `settings.json` in `.ai/.claude/`.
+
+## Generated .mcp.json
+
+MCP servers are written to `.mcp.json` at the project root (not inside `.claude/`), because Claude Code [does not read `mcpServers` from `settings.json`](https://github.com/anthropics/claude-code/issues/24477):
+
+```json
+{
   "mcpServers": {
     "memory": {
       "command": "npx",
@@ -46,5 +59,3 @@ Settings are passed through directly in Claude format:
   }
 }
 ```
-
-To override the generated settings, place a custom `settings.json` in `.ai/.claude/`.

--- a/packages/core/src/plugins/claude-code/index.test.ts
+++ b/packages/core/src/plugins/claude-code/index.test.ts
@@ -127,7 +127,26 @@ describe("claudeCodePlugin", () => {
       });
     });
 
-    it("creates settings.json with mcpServers", async () => {
+    it("creates .mcp.json at project root with mcpServers", async () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            db: { command: "npx", args: ["-y", "@example/db"] },
+          },
+        },
+      });
+
+      const files = await claudeCodePlugin.export(state, tempDir);
+
+      const mcpJson = files.find((f) => f.path === ".mcp.json");
+      expect(mcpJson).toBeDefined();
+      expect(mcpJson?.type).toBe("json");
+      expect(
+        (mcpJson?.content as Record<string, unknown>)["mcpServers"]
+      ).toBeDefined();
+    });
+
+    it("does not put mcpServers in settings.json", async () => {
       const state = createMinimalState({
         settings: {
           mcpServers: {
@@ -139,10 +158,11 @@ describe("claudeCodePlugin", () => {
       const files = await claudeCodePlugin.export(state, tempDir);
 
       const settings = files.find((f) => f.path === ".claude/settings.json");
-      expect(settings).toBeDefined();
       expect(
-        (settings?.content as Record<string, unknown>)["mcpServers"]
-      ).toBeDefined();
+        (settings?.content as Record<string, unknown> | undefined)?.[
+          "mcpServers"
+        ]
+      ).toBeUndefined();
     });
 
     it("skips settings.json when no settings content", async () => {

--- a/packages/core/src/plugins/claude-code/index.test.ts
+++ b/packages/core/src/plugins/claude-code/index.test.ts
@@ -149,6 +149,9 @@ describe("claudeCodePlugin", () => {
     it("does not put mcpServers in settings.json", async () => {
       const state = createMinimalState({
         settings: {
+          permissions: {
+            allow: ["Bash(git:*)"],
+          },
           mcpServers: {
             db: { command: "npx", args: ["-y", "@example/db"] },
           },
@@ -158,11 +161,23 @@ describe("claudeCodePlugin", () => {
       const files = await claudeCodePlugin.export(state, tempDir);
 
       const settings = files.find((f) => f.path === ".claude/settings.json");
+      expect(settings).toBeDefined();
       expect(
-        (settings?.content as Record<string, unknown> | undefined)?.[
-          "mcpServers"
-        ]
+        (settings?.content as Record<string, unknown>)["mcpServers"]
       ).toBeUndefined();
+    });
+
+    it("skips .mcp.json when mcpServers is empty", async () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {},
+        },
+      });
+
+      const files = await claudeCodePlugin.export(state, tempDir);
+
+      const mcpJson = files.find((f) => f.path === ".mcp.json");
+      expect(mcpJson).toBeUndefined();
     });
 
     it("skips settings.json when no settings content", async () => {
@@ -179,7 +194,7 @@ describe("claudeCodePlugin", () => {
 
       const files = await claudeCodePlugin.export(state, tempDir);
 
-      // Should have CLAUDE.md, rules, skills, and settings
+      // Should have CLAUDE.md, rules, skills, settings, and .mcp.json
       expect(files.find((f) => f.path === ".claude/CLAUDE.md")).toBeDefined();
       expect(files.find((f) => f.path === ".claude/rules")).toBeDefined();
       expect(
@@ -188,6 +203,7 @@ describe("claudeCodePlugin", () => {
       expect(
         files.find((f) => f.path === ".claude/settings.json")
       ).toBeDefined();
+      expect(files.find((f) => f.path === ".mcp.json")).toBeDefined();
     });
 
     describe("file symlinks", () => {

--- a/packages/core/src/plugins/claude-code/index.ts
+++ b/packages/core/src/plugins/claude-code/index.ts
@@ -61,15 +61,23 @@ export const claudeCodePlugin: Plugin = {
     if (state.settings?.permissions) {
       settings["permissions"] = state.settings.permissions;
     }
-    if (state.settings?.mcpServers) {
-      settings["mcpServers"] = state.settings.mcpServers;
-    }
 
     if (Object.keys(settings).length > 0) {
       files.push({
         path: `${OUTPUT_DIR}/settings.json`,
         type: "json",
         content: settings,
+      });
+    }
+
+    if (
+      state.settings?.mcpServers &&
+      Object.keys(state.settings.mcpServers).length > 0
+    ) {
+      files.push({
+        path: ".mcp.json",
+        type: "json",
+        content: { mcpServers: state.settings.mcpServers },
       });
     }
 

--- a/packages/core/src/plugins/claude-code/index.ts
+++ b/packages/core/src/plugins/claude-code/index.ts
@@ -21,7 +21,8 @@ const OUTPUT_DIR = TOOL_OUTPUT_DIRS.claudeCode;
  * - .claude/CLAUDE.md (symlink -> ../.ai/AGENTS.md)
  * - .claude/rules/ (symlink -> ../.ai/rules)
  * - .claude/skills/<name>/ (symlink -> ../../.ai/skills/<name>)
- * - .claude/settings.json (generated settings merged with .ai/.claude/settings.json)
+ * - .claude/settings.json (generated permissions, merged with .ai/.claude/settings.json)
+ * - .mcp.json (generated mcpServers at project root)
  * - .claude/<path> (symlink -> ../.ai/.claude/<path>) for other override files
  */
 export const claudeCodePlugin: Plugin = {


### PR DESCRIPTION
## Problem

Claude Code **silently ignores** `mcpServers` in `.claude/settings.json` — the key is accepted without error but never acted on. This means MCP servers configured via `lnai sync` were never loaded in Claude Code.

This is a confirmed upstream issue:
- anthropics/claude-code#24477 — "[DOCS] Add warning that mcpServers in settings.json is silently ignored"
- anthropics/claude-code#4976 — "Documentation incorrect about MCP configuration file location"

The correct project-scope location is `.mcp.json` at the repo root — the same pattern the Cursor plugin already uses (`.cursor/mcp.json`).

## Fix

**`packages/core/src/plugins/claude-code/index.ts`**
- Remove `mcpServers` from the `settings.json` output block
- Generate `.mcp.json` at project root with `{ "mcpServers": { ... } }`
- Skip `.mcp.json` generation when `mcpServers` is empty

**`packages/core/src/plugins/claude-code/index.test.ts`**
- Replace old test (mcpServers in settings.json) with two new tests:
  - `.mcp.json` is generated at project root with `mcpServers`
  - `.claude/settings.json` has no `mcpServers` key

All 499 tests pass.

## Checklist
- [x] Tests updated and passing
- [x] Matches behaviour of the Cursor plugin (`.cursor/mcp.json`)
- [x] No breaking changes to `settings.json` for users who only use `permissions`

---
*PR assisted by Claude Code*