### PR TITLE
chore: dependency maintenance — all deps current, 0 audit vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Audit
+        run: pnpm audit --prod --audit-level high
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Knip
+        run: pnpm knip
+
       - name: Format check
         run: pnpm format:check
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 pnpm lint-staged
 pnpm typecheck
+pnpm knip

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnai",
-  "version": "0.6.91",
+  "version": "0.6.92",
   "description": "CLI tool that syncs a unified .ai/ config to native formats for AI coding tools",
   "type": "module",
   "license": "MIT",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -50,18 +50,18 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@inquirer/prompts": "^7.0.0",
+    "@inquirer/prompts": "^8.5.2",
     "@lnai/core": "workspace:*",
     "chalk": "^5.6.2",
-    "commander": "^14.0.2",
-    "ora": "^9.1.0"
+    "commander": "^15.0.0",
+    "ora": "^9.4.0"
   },
   "devDependencies": {
     "@lnai/typescript-config": "workspace:*",
-    "@types/node": "^25.0.10",
-    "eslint": "^9.39.2",
+    "@types/node": "^25.9.3",
+    "eslint": "^10.4.1",
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3",
-    "vitest": "^4.0.18"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   }
 }

--- a/apps/cli/src/utils/format.ts
+++ b/apps/cli/src/utils/format.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 
-export const GITHUB_URL = "https://github.com/KrystianJonca/lnai";
+const GITHUB_URL = "https://github.com/KrystianJonca/lnai";
 
 export interface ValidationItem {
   path: string[];
@@ -10,7 +10,7 @@ export interface ValidationItem {
 /**
  * Format a single validation item (error or warning) as a string.
  */
-export function formatValidationItem(
+function formatValidationItem(
   item: ValidationItem,
   color: "red" | "yellow"
 ): string {

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -29,15 +29,15 @@ export default defineConfig({
       sidebar: [
         {
           label: "Getting Started",
-          autogenerate: { directory: "getting-started" },
+          items: [{ autogenerate: { directory: "getting-started" } }],
         },
         {
           label: "Reference",
-          autogenerate: { directory: "reference" },
+          items: [{ autogenerate: { directory: "reference" } }],
         },
         {
           label: "Tools",
-          autogenerate: { directory: "tools" },
+          items: [{ autogenerate: { directory: "tools" } }],
         },
       ],
       head: [

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,7 +18,6 @@
     "sharp": "^0.35.1"
   },
   "devDependencies": {
-    "@lnai/typescript-config": "workspace:*",
     "eslint": "^10.4.1",
     "typescript": "^6.0.3"
   }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,13 +13,13 @@
     "clean": "rm -rf dist .turbo .astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.37.4",
-    "astro": "^5.16.15",
-    "sharp": "^0.34.5"
+    "@astrojs/starlight": "^0.40.0",
+    "astro": "^6.4.6",
+    "sharp": "^0.35.1"
   },
   "devDependencies": {
     "@lnai/typescript-config": "workspace:*",
-    "eslint": "^9.39.2",
-    "typescript": "^5.9.3"
+    "eslint": "^10.4.1",
+    "typescript": "^6.0.3"
   }
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "workspaces": {
+    ".": {
+      // lnai is the published CLI installed at the root to dogfood
+      // syncing this repo's own .ai/ config (run manually, not via scripts)
+      "ignoreDependencies": ["lnai"],
+    },
+  },
+}

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "@lnai/eslint-config": "workspace:*",
     "@lnai/prettier-config": "workspace:*",
     "@lnai/typescript-config": "workspace:*",
-    "eslint": "^9.39.2",
+    "eslint": "^10.4.1",
     "husky": "^9.1.7",
-    "lint-staged": "^16.2.7",
-    "lnai": "^0.6.5",
-    "prettier": "^3.8.1",
-    "turbo": "^2.7.6",
-    "typescript": "^5.9.3"
+    "lint-staged": "^17.0.7",
+    "lnai": "^0.6.91",
+    "prettier": "^3.8.4",
+    "turbo": "^2.9.18",
+    "typescript": "^6.0.3"
   },
   "packageManager": "pnpm@10.28.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "typecheck": "turbo run typecheck",
+    "knip": "knip",
     "format": "prettier --ignore-path .gitignore --write .",
     "format:check": "prettier --ignore-path .gitignore --check .",
     "clean": "turbo run clean && rm -rf node_modules",
@@ -20,9 +21,9 @@
   "devDependencies": {
     "@lnai/eslint-config": "workspace:*",
     "@lnai/prettier-config": "workspace:*",
-    "@lnai/typescript-config": "workspace:*",
     "eslint": "^10.4.1",
     "husky": "^9.1.7",
+    "knip": "^6.16.1",
     "lint-staged": "^17.0.7",
     "lnai": "^0.6.91",
     "prettier": "^3.8.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lnai/core",
-  "version": "0.6.91",
+  "version": "0.6.92",
   "description": "Core library for LNAI - unified AI config management",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,14 +50,14 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.3",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@lnai/typescript-config": "workspace:*",
-    "@types/node": "^25.0.10",
-    "eslint": "^9.39.2",
+    "@types/node": "^25.9.3",
+    "eslint": "^10.4.1",
     "tsup": "^8.5.1",
-    "typescript": "^5.9.3",
-    "vitest": "^4.0.18"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,9 +70,13 @@ export {
 export {
   claudeCodePlugin,
   codexPlugin,
+  copilotPlugin,
+  cursorPlugin,
+  geminiPlugin,
   opencodePlugin,
   type Plugin,
   pluginRegistry,
+  windsurfPlugin,
 } from "./plugins/index";
 
 // Pipeline

--- a/packages/core/src/plugins/cursor/transforms.ts
+++ b/packages/core/src/plugins/cursor/transforms.ts
@@ -12,7 +12,6 @@ import type {
 } from "./types";
 
 export type {
-  CursorPermissions,
   CursorRuleFrontmatter,
   TransformPermissionsResult,
 } from "./types";

--- a/packages/core/src/plugins/cursor/types.ts
+++ b/packages/core/src/plugins/cursor/types.ts
@@ -13,7 +13,7 @@ export interface CursorMcpServer {
   headers?: Record<string, string>;
 }
 
-export interface CursorPermissions {
+interface CursorPermissions {
   allow: string[];
   deny: string[];
 }

--- a/packages/core/src/plugins/gemini/types.ts
+++ b/packages/core/src/plugins/gemini/types.ts
@@ -1,4 +1,4 @@
-export interface GeminiMcpServer {
+interface GeminiMcpServer {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
@@ -7,9 +7,4 @@ export interface GeminiMcpServer {
 
 export interface GeminiMcpSettings {
   [key: string]: GeminiMcpServer;
-}
-
-export interface GeminiRule {
-  dir: string;
-  content: string;
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,0 @@
-export * from "./agents";
-export * from "./mcp";
-export * from "./overrides";
-export * from "./transforms";

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
-  dts: true,
+  // tsup injects baseUrl into its DTS build, which TS 6 deprecates (TS5101)
+  dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
   clean: true,
   sourcemap: false,
   splitting: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,15 +13,15 @@ importers:
       "@lnai/prettier-config":
         specifier: workspace:*
         version: link:tooling/prettier-config
-      "@lnai/typescript-config":
-        specifier: workspace:*
-        version: link:tooling/typescript-config
       eslint:
         specifier: ^10.4.1
-        version: 10.4.1
+        version: 10.4.1(jiti@2.7.0)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      knip:
+        specifier: ^6.16.1
+        version: 6.16.1
       lint-staged:
         specifier: ^17.0.7
         version: 17.0.7
@@ -64,35 +64,32 @@ importers:
         version: 25.9.3
       eslint:
         specifier: ^10.4.1
-        version: 10.4.1
+        version: 10.4.1(jiti@2.7.0)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
       "@astrojs/starlight":
         specifier: ^0.40.0
-        version: 0.40.0(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)
+        version: 0.40.0(astro@6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)
       astro:
         specifier: ^6.4.6
-        version: 6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)
+        version: 6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0)
       sharp:
         specifier: ^0.35.1
         version: 0.35.1
     devDependencies:
-      "@lnai/typescript-config":
-        specifier: workspace:*
-        version: link:../../tooling/typescript-config
       eslint:
         specifier: ^10.4.1
-        version: 10.4.1
+        version: 10.4.1(jiti@2.7.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -114,31 +111,31 @@ importers:
         version: 25.9.3
       eslint:
         specifier: ^10.4.1
-        version: 10.4.1
+        version: 10.4.1(jiti@2.7.0)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
 
   tooling/eslint-config:
     dependencies:
       "@eslint/js":
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.4.1)
+        version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       "@typescript-eslint/eslint-plugin":
         specifier: ^8.61.0
-        version: 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)
+        version: 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       "@typescript-eslint/parser":
         specifier: ^8.61.0
-        version: 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+        version: 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       eslint-plugin-simple-import-sort:
         specifier: ^13.0.0
-        version: 13.0.0(eslint@10.4.1)
+        version: 13.0.0(eslint@10.4.1(jiti@2.7.0))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -148,23 +145,15 @@ importers:
     devDependencies:
       eslint:
         specifier: ^10.4.1
-        version: 10.4.1
+        version: 10.4.1(jiti@2.7.0)
 
   tooling/prettier-config:
     dependencies:
       prettier:
         specifier: ^3.0.0
         version: 3.8.4
-    devDependencies:
-      eslint:
-        specifier: ^10.4.1
-        version: 10.4.1
 
-  tooling/typescript-config:
-    devDependencies:
-      eslint:
-        specifier: ^10.4.1
-        version: 10.4.1
+  tooling/typescript-config: {}
 
 packages:
   "@astrojs/compiler@4.0.0":
@@ -287,10 +276,28 @@ packages:
       }
     engines: { node: ">=14" }
 
+  "@emnapi/core@1.10.0":
+    resolution:
+      {
+        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
+      }
+
+  "@emnapi/runtime@1.10.0":
+    resolution:
+      {
+        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
+      }
+
   "@emnapi/runtime@1.11.0":
     resolution:
       {
         integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==,
+      }
+
+  "@emnapi/wasi-threads@1.2.1":
+    resolution:
+      {
+        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
 
   "@esbuild/aix-ppc64@0.27.7":
@@ -1482,11 +1489,357 @@ packages:
         integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==,
       }
 
+  "@napi-rs/wasm-runtime@1.1.5":
+    resolution:
+      {
+        integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==,
+      }
+    peerDependencies:
+      "@emnapi/core": ^1.7.1
+      "@emnapi/runtime": ^1.7.1
+
   "@oslojs/encoding@1.1.0":
     resolution:
       {
         integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==,
       }
+
+  "@oxc-parser/binding-android-arm-eabi@0.133.0":
+    resolution:
+      {
+        integrity: sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-parser/binding-android-arm64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-KUHmPMziLBp4u+zbrLdB7iWS7KshuZe+RAp7ELnY9SI9nNXBZ+dp8fiBqWOxhXqn+FQg3a4UcQhwmsJOKV8Jjg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-parser/binding-darwin-arm64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-q8dWmnU/8ea2tga9w2f1PinQ5rcMPDUGkF64T189b65YMjUomET4oy5oRldOr4AwOQkneOG/Zttnz1Dvrc62wg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-parser/binding-darwin-x64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-cOKeIELIB2bJnCKwqx4Rdj+1Lss/U6uCbLxRySZrhyOOQa1flKhwZFjEHRHxk8fU1NKmhK5OnTdPQ4CpjuFuVw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-parser/binding-freebsd-x64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-OpaSv4pW3KgFrMYQxTaS0aOE4T1DQF3qZE/4B6uqqv1KgPWWd4UQhJALi8PJPX1RRV5K7ThKXRfF7qGg2+3l1A==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.133.0":
+    resolution:
+      {
+        integrity: sha512-JGK1wlGrGwxBIlVSF7KWTX1/ru6BEtf28fRROztDRkLfiW+Kxa4onnriezMIiogfn9hVw2KzYcKiLjkLR2ns8A==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.133.0":
+    resolution:
+      {
+        integrity: sha512-yuZO533Ftonxn/iyoqQzURzLQHMspvsIyfiCSNi1t/ER4eIQaR0SsmUOUm5b/lmSig7IWIUa5/BrbEkAPwcilQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-hvpbqT5pN2rR+3+xtWeizwfR/aZ0vGceg6TqYMl+ToxMpk9/tmnX7kSvQnfEUkoua8mhogzvIKsAkn0wxgblBA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm64-musl@0.133.0":
+    resolution:
+      {
+        integrity: sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.133.0":
+    resolution:
+      {
+        integrity: sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-x64-gnu@0.133.0":
+    resolution:
+      {
+        integrity: sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-x64-musl@0.133.0":
+    resolution:
+      {
+        integrity: sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@oxc-parser/binding-openharmony-arm64@0.133.0":
+    resolution:
+      {
+        integrity: sha512-51aByfXhPtLEdWG4a2Ihdw6cPWV1ei1AarALpFdDP8MLWDLE2NuUMgbo3DERR2Kt8fT/ok1GUvBiLxVGke9uUQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-parser/binding-wasm32-wasi@0.133.0":
+    resolution:
+      {
+        integrity: sha512-2e16tkKp+wDO2GTAmXfxbBcCmGEaFPIJEIRBBmVKNVXSc8/fJsSIaBGyFTPHM9ST5GNWgJcYIt94rDTks+PLwA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.133.0":
+    resolution:
+      {
+        integrity: sha512-KPTNDKbxH1cglrqTyVeXHb4Pk4oksz8EcE1/v8zqU7N4UXbiHfA/IwtXZ2U77fnRAWBbgVkl/lZbL7o3hRdejg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.133.0":
+    resolution:
+      {
+        integrity: sha512-Una1bNYv9zCavQrfnDR9wuZVB3itLjCEH4Oz7i6CwAJN/Xq9b+zbbcxmvdkKvvJt4Ngc/MBmIYlbLo3zS4TQ0A==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-x64-msvc@0.133.0":
+    resolution:
+      {
+        integrity: sha512-kjBhCiOGSYTwDJQuuZa7a94JbP8htWu7J0X1KwH74kV2K5eYf6eyJRYmkpCDvr0XEL8tMxYI4WU1VekblFCLgg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@oxc-project/types@0.133.0":
+    resolution:
+      {
+        integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==,
+      }
+
+  "@oxc-resolver/binding-android-arm-eabi@11.20.0":
+    resolution:
+      {
+        integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==,
+      }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-resolver/binding-android-arm64@11.20.0":
+    resolution:
+      {
+        integrity: sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==,
+      }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-resolver/binding-darwin-arm64@11.20.0":
+    resolution:
+      {
+        integrity: sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-resolver/binding-darwin-x64@11.20.0":
+    resolution:
+      {
+        integrity: sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-resolver/binding-freebsd-x64@11.20.0":
+    resolution:
+      {
+        integrity: sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==,
+      }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0":
+    resolution:
+      {
+        integrity: sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==,
+      }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-arm-musleabihf@11.20.0":
+    resolution:
+      {
+        integrity: sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==,
+      }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-arm64-gnu@11.20.0":
+    resolution:
+      {
+        integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-arm64-musl@11.20.0":
+    resolution:
+      {
+        integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-ppc64-gnu@11.20.0":
+    resolution:
+      {
+        integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-riscv64-gnu@11.20.0":
+    resolution:
+      {
+        integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-riscv64-musl@11.20.0":
+    resolution:
+      {
+        integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-s390x-gnu@11.20.0":
+    resolution:
+      {
+        integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==,
+      }
+    cpu: [s390x]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-x64-gnu@11.20.0":
+    resolution:
+      {
+        integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==,
+      }
+    cpu: [x64]
+    os: [linux]
+
+  "@oxc-resolver/binding-linux-x64-musl@11.20.0":
+    resolution:
+      {
+        integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==,
+      }
+    cpu: [x64]
+    os: [linux]
+
+  "@oxc-resolver/binding-openharmony-arm64@11.20.0":
+    resolution:
+      {
+        integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==,
+      }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-resolver/binding-wasm32-wasi@11.20.0":
+    resolution:
+      {
+        integrity: sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==,
+      }
+    engines: { node: ">=14.0.0" }
+    cpu: [wasm32]
+
+  "@oxc-resolver/binding-win32-arm64-msvc@11.20.0":
+    resolution:
+      {
+        integrity: sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-resolver/binding-win32-x64-msvc@11.20.0":
+    resolution:
+      {
+        integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==,
+      }
+    cpu: [x64]
+    os: [win32]
 
   "@pagefind/darwin-arm64@1.5.2":
     resolution:
@@ -1870,6 +2223,12 @@ packages:
       }
     cpu: [arm64]
     os: [win32]
+
+  "@tybys/wasm-util@0.10.2":
+    resolution:
+      {
+        integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
+      }
 
   "@types/chai@5.2.3":
     resolution:
@@ -2957,6 +3316,12 @@ packages:
         integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==,
       }
 
+  fd-package-json@2.0.0:
+    resolution:
+      {
+        integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==,
+      }
+
   fdir@6.5.0:
     resolution:
       {
@@ -3022,6 +3387,14 @@ packages:
       }
     engines: { node: ">=20" }
 
+  formatly@0.3.0:
+    resolution:
+      {
+        integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==,
+      }
+    engines: { node: ">=18.3.0" }
+    hasBin: true
+
   fsevents@2.3.3:
     resolution:
       {
@@ -3036,6 +3409,12 @@ packages:
         integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==,
       }
     engines: { node: ">=18" }
+
+  get-tsconfig@4.14.0:
+    resolution:
+      {
+        integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==,
+      }
 
   get-tsconfig@5.0.0-beta.4:
     resolution:
@@ -3397,6 +3776,13 @@ packages:
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
       }
 
+  jiti@2.7.0:
+    resolution:
+      {
+        integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
+      }
+    hasBin: true
+
   joycon@3.1.1:
     resolution:
       {
@@ -3461,6 +3847,14 @@ packages:
         integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==,
       }
     engines: { node: ">= 8" }
+
+  knip@6.16.1:
+    resolution:
+      {
+        integrity: sha512-TKMn1rxgH6h9vXR9Y0B+Cq7AdPTr9EI02IwoT65NzqYUkvoDQAaJ/aPybiFpAhZ1px6cNYYwXf86iHkBgzCo9w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
 
   levn@0.4.1:
     resolution:
@@ -4069,6 +4463,19 @@ packages:
         integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==,
       }
     engines: { node: ">=20" }
+
+  oxc-parser@0.133.0:
+    resolution:
+      {
+        integrity: sha512-661RSx+ZcjBmjBYid+Fpp/2F5EbtildpeoZh5HdgnGs+jZ03nqQEQW8yGkt4BGyOC3OMPDQQRl8M5kqD2/g6jw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+
+  oxc-resolver@11.20.0:
+    resolution:
+      {
+        integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==,
+      }
 
   p-limit@3.1.0:
     resolution:
@@ -4698,6 +5105,13 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  strip-json-comments@5.0.3:
+    resolution:
+      {
+        integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
+      }
+    engines: { node: ">=14.16" }
+
   style-to-js@1.1.21:
     resolution:
       {
@@ -4880,6 +5294,13 @@ packages:
       {
         integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==,
       }
+
+  unbash@3.0.0:
+    resolution:
+      {
+        integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==,
+      }
+    engines: { node: ">=14" }
 
   uncrypto@0.1.3:
     resolution:
@@ -5164,6 +5585,13 @@ packages:
       jsdom:
         optional: true
 
+  walk-up-path@4.0.0:
+    resolution:
+      {
+        integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==,
+      }
+    engines: { node: 20 || >=22 }
+
   web-namespaces@2.0.1:
     resolution:
       {
@@ -5318,13 +5746,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@6.0.3(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))":
+  "@astrojs/mdx@6.0.3(astro@6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0))":
     dependencies:
       "@astrojs/internal-helpers": 0.10.0
       "@astrojs/markdown-remark": 7.2.0
       "@mdx-js/mdx": 3.1.1
       acorn: 8.17.0
-      astro: 6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)
+      astro: 6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5348,17 +5776,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  "@astrojs/starlight@0.40.0(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)":
+  "@astrojs/starlight@0.40.0(astro@6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)":
     dependencies:
       "@astrojs/markdown-remark": 7.2.0
-      "@astrojs/mdx": 6.0.3(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))
+      "@astrojs/mdx": 6.0.3(astro@6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0))
       "@astrojs/sitemap": 3.7.3
       "@pagefind/default-ui": 1.5.2
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)
-      astro-expressive-code: 0.43.1(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))
+      astro: 6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0)
+      astro-expressive-code: 0.43.1(astro@6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -5422,7 +5850,23 @@ snapshots:
 
   "@ctrl/tinycolor@4.2.0": {}
 
+  "@emnapi/core@1.10.0":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.10.0":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   "@emnapi/runtime@1.11.0":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.1":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5505,9 +5949,9 @@ snapshots:
   "@esbuild/win32-x64@0.27.7":
     optional: true
 
-  "@eslint-community/eslint-utils@4.9.1(eslint@10.4.1)":
+  "@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0))":
     dependencies:
-      eslint: 10.4.1
+      eslint: 10.4.1(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   "@eslint-community/regexpp@4.12.2": {}
@@ -5528,9 +5972,9 @@ snapshots:
     dependencies:
       "@types/json-schema": 7.0.15
 
-  "@eslint/js@10.0.1(eslint@10.4.1)":
+  "@eslint/js@10.0.1(eslint@10.4.1(jiti@2.7.0))":
     optionalDependencies:
-      eslint: 10.4.1
+      eslint: 10.4.1(jiti@2.7.0)
 
   "@eslint/object-schema@3.0.5": {}
 
@@ -6073,7 +6517,141 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@tybys/wasm-util": 0.10.2
+    optional: true
+
   "@oslojs/encoding@1.1.0": {}
+
+  "@oxc-parser/binding-android-arm-eabi@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-android-arm64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-arm64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-x64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-freebsd-x64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-musl@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-gnu@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-musl@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-openharmony-arm64@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-wasm32-wasi@0.133.0":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.133.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-x64-msvc@0.133.0":
+    optional: true
+
+  "@oxc-project/types@0.133.0": {}
+
+  "@oxc-resolver/binding-android-arm-eabi@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-android-arm64@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-darwin-arm64@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-darwin-x64@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-freebsd-x64@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm-musleabihf@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm64-gnu@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-arm64-musl@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-ppc64-gnu@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-riscv64-gnu@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-riscv64-musl@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-s390x-gnu@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-x64-gnu@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-linux-x64-musl@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-openharmony-arm64@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-wasm32-wasi@11.20.0":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  "@oxc-resolver/binding-win32-arm64-msvc@11.20.0":
+    optional: true
+
+  "@oxc-resolver/binding-win32-x64-msvc@11.20.0":
+    optional: true
 
   "@pagefind/darwin-arm64@1.5.2":
     optional: true
@@ -6241,6 +6819,11 @@ snapshots:
   "@turbo/windows-arm64@2.9.18":
     optional: true
 
+  "@tybys/wasm-util@0.10.2":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   "@types/chai@5.2.3":
     dependencies:
       "@types/deep-eql": 4.0.2
@@ -6296,15 +6879,15 @@ snapshots:
 
   "@types/unist@3.0.3": {}
 
-  "@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)":
+  "@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      "@typescript-eslint/parser": 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       "@typescript-eslint/scope-manager": 8.61.0
-      "@typescript-eslint/type-utils": 8.61.0(eslint@10.4.1)(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      "@typescript-eslint/type-utils": 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       "@typescript-eslint/visitor-keys": 8.61.0
-      eslint: 10.4.1
+      eslint: 10.4.1(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -6312,14 +6895,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.61.0(eslint@10.4.1)(typescript@6.0.3)":
+  "@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)":
     dependencies:
       "@typescript-eslint/scope-manager": 8.61.0
       "@typescript-eslint/types": 8.61.0
       "@typescript-eslint/typescript-estree": 8.61.0(typescript@6.0.3)
       "@typescript-eslint/visitor-keys": 8.61.0
       debug: 4.4.3
-      eslint: 10.4.1
+      eslint: 10.4.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6342,13 +6925,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  "@typescript-eslint/type-utils@8.61.0(eslint@10.4.1)(typescript@6.0.3)":
+  "@typescript-eslint/type-utils@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)":
     dependencies:
       "@typescript-eslint/types": 8.61.0
       "@typescript-eslint/typescript-estree": 8.61.0(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.4.1
+      eslint: 10.4.1(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6371,13 +6954,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.61.0(eslint@10.4.1)(typescript@6.0.3)":
+  "@typescript-eslint/utils@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)":
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.1)
+      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.1(jiti@2.7.0))
       "@typescript-eslint/scope-manager": 8.61.0
       "@typescript-eslint/types": 8.61.0
       "@typescript-eslint/typescript-estree": 8.61.0(typescript@6.0.3)
-      eslint: 10.4.1
+      eslint: 10.4.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6398,13 +6981,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.8(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))":
+  "@vitest/mocker@4.1.8(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))":
     dependencies:
       "@vitest/spy": 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)
 
   "@vitest/pretty-format@4.1.8":
     dependencies:
@@ -6480,12 +7063,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.43.1(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)):
+  astro-expressive-code@0.43.1(astro@6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0)):
     dependencies:
-      astro: 6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)
+      astro: 6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0)
       rehype-expressive-code: 0.43.1
 
-  astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0):
+  astro@6.4.6(@types/node@25.9.3)(jiti@2.7.0)(rollup@4.61.1)(yaml@2.9.0):
     dependencies:
       "@astrojs/compiler": 4.0.0
       "@astrojs/internal-helpers": 0.10.0
@@ -6537,8 +7120,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -6821,9 +7404,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-simple-import-sort@13.0.0(eslint@10.4.1):
+  eslint-plugin-simple-import-sort@13.0.0(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.1
+      eslint: 10.4.1(jiti@2.7.0)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -6836,9 +7419,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.4.1:
+  eslint@10.4.1(jiti@2.7.0):
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.1)
+      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.1(jiti@2.7.0))
       "@eslint-community/regexpp": 4.12.2
       "@eslint/config-array": 0.23.5
       "@eslint/config-helpers": 0.6.0
@@ -6868,6 +7451,8 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6959,6 +7544,10 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -6995,10 +7584,18 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
+
   fsevents@2.3.3:
     optional: true
 
   get-east-asian-width@1.6.0: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@5.0.0-beta.4:
     dependencies:
@@ -7293,6 +7890,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jiti@2.7.0: {}
+
   joycon@3.1.1: {}
 
   js-yaml@3.14.2:
@@ -7319,6 +7918,22 @@ snapshots:
   kind-of@6.0.3: {}
 
   klona@2.0.6: {}
+
+  knip@6.16.1:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.0
+      jiti: 2.7.0
+      oxc-parser: 0.133.0
+      oxc-resolver: 11.20.0
+      picomatch: 4.0.4
+      smol-toml: 1.6.1
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 3.0.0
+      yaml: 2.9.0
+      zod: 4.4.3
 
   levn@0.4.1:
     dependencies:
@@ -7945,6 +8560,53 @@ snapshots:
       stdin-discarder: 0.3.2
       string-width: 8.2.1
 
+  oxc-parser@0.133.0:
+    dependencies:
+      "@oxc-project/types": 0.133.0
+    optionalDependencies:
+      "@oxc-parser/binding-android-arm-eabi": 0.133.0
+      "@oxc-parser/binding-android-arm64": 0.133.0
+      "@oxc-parser/binding-darwin-arm64": 0.133.0
+      "@oxc-parser/binding-darwin-x64": 0.133.0
+      "@oxc-parser/binding-freebsd-x64": 0.133.0
+      "@oxc-parser/binding-linux-arm-gnueabihf": 0.133.0
+      "@oxc-parser/binding-linux-arm-musleabihf": 0.133.0
+      "@oxc-parser/binding-linux-arm64-gnu": 0.133.0
+      "@oxc-parser/binding-linux-arm64-musl": 0.133.0
+      "@oxc-parser/binding-linux-ppc64-gnu": 0.133.0
+      "@oxc-parser/binding-linux-riscv64-gnu": 0.133.0
+      "@oxc-parser/binding-linux-riscv64-musl": 0.133.0
+      "@oxc-parser/binding-linux-s390x-gnu": 0.133.0
+      "@oxc-parser/binding-linux-x64-gnu": 0.133.0
+      "@oxc-parser/binding-linux-x64-musl": 0.133.0
+      "@oxc-parser/binding-openharmony-arm64": 0.133.0
+      "@oxc-parser/binding-wasm32-wasi": 0.133.0
+      "@oxc-parser/binding-win32-arm64-msvc": 0.133.0
+      "@oxc-parser/binding-win32-ia32-msvc": 0.133.0
+      "@oxc-parser/binding-win32-x64-msvc": 0.133.0
+
+  oxc-resolver@11.20.0:
+    optionalDependencies:
+      "@oxc-resolver/binding-android-arm-eabi": 11.20.0
+      "@oxc-resolver/binding-android-arm64": 11.20.0
+      "@oxc-resolver/binding-darwin-arm64": 11.20.0
+      "@oxc-resolver/binding-darwin-x64": 11.20.0
+      "@oxc-resolver/binding-freebsd-x64": 11.20.0
+      "@oxc-resolver/binding-linux-arm-gnueabihf": 11.20.0
+      "@oxc-resolver/binding-linux-arm-musleabihf": 11.20.0
+      "@oxc-resolver/binding-linux-arm64-gnu": 11.20.0
+      "@oxc-resolver/binding-linux-arm64-musl": 11.20.0
+      "@oxc-resolver/binding-linux-ppc64-gnu": 11.20.0
+      "@oxc-resolver/binding-linux-riscv64-gnu": 11.20.0
+      "@oxc-resolver/binding-linux-riscv64-musl": 11.20.0
+      "@oxc-resolver/binding-linux-s390x-gnu": 11.20.0
+      "@oxc-resolver/binding-linux-x64-gnu": 11.20.0
+      "@oxc-resolver/binding-linux-x64-musl": 11.20.0
+      "@oxc-resolver/binding-openharmony-arm64": 11.20.0
+      "@oxc-resolver/binding-wasm32-wasi": 11.20.0
+      "@oxc-resolver/binding-win32-arm64-msvc": 11.20.0
+      "@oxc-resolver/binding-win32-x64-msvc": 11.20.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -8021,10 +8683,11 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.15)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      jiti: 2.7.0
       postcss: 8.5.15
       yaml: 2.9.0
 
@@ -8432,6 +9095,8 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  strip-json-comments@5.0.3: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -8500,7 +9165,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -8511,7 +9176,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.15)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.61.1
       source-map: 0.7.6
@@ -8546,6 +9211,8 @@ snapshots:
   ufo@1.6.4: {}
 
   ultrahtml@1.6.0: {}
+
+  unbash@3.0.0: {}
 
   uncrypto@0.1.3: {}
 
@@ -8647,7 +9314,7 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0):
+  vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8658,16 +9325,17 @@ snapshots:
     optionalDependencies:
       "@types/node": 25.9.3
       fsevents: 2.3.3
+      jiti: 2.7.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)
 
-  vitest@4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       "@vitest/expect": 4.1.8
-      "@vitest/mocker": 4.1.8(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
+      "@vitest/mocker": 4.1.8(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))
       "@vitest/pretty-format": 4.1.8
       "@vitest/runner": 4.1.8
       "@vitest/snapshot": 4.1.8
@@ -8684,12 +9352,14 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 25.9.3
     transitivePeerDependencies:
       - msw
+
+  walk-up-path@4.0.0: {}
 
   web-namespaces@2.0.1: {}
 
@@ -8726,8 +9396,7 @@ snapshots:
 
   xxhash-wasm@1.1.0: {}
 
-  yaml@2.9.0:
-    optional: true
+  yaml@2.9.0: {}
 
   yargs-parser@22.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,32 +17,32 @@ importers:
         specifier: workspace:*
         version: link:tooling/typescript-config
       eslint:
-        specifier: ^9.39.2
-        version: 9.39.2
+        specifier: ^10.4.1
+        version: 10.4.1
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^16.2.7
-        version: 16.2.7
+        specifier: ^17.0.7
+        version: 17.0.7
       lnai:
-        specifier: ^0.6.5
-        version: 0.6.5(@types/node@25.0.10)
+        specifier: ^0.6.91
+        version: 0.6.91(@types/node@25.9.3)
       prettier:
-        specifier: ^3.8.1
-        version: 3.8.1
+        specifier: ^3.8.4
+        version: 3.8.4
       turbo:
-        specifier: ^2.7.6
-        version: 2.7.6
+        specifier: ^2.9.18
+        version: 2.9.18
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   apps/cli:
     dependencies:
       "@inquirer/prompts":
-        specifier: ^7.0.0
-        version: 7.10.1(@types/node@25.0.10)
+        specifier: ^8.5.2
+        version: 8.5.2(@types/node@25.9.3)
       "@lnai/core":
         specifier: workspace:*
         version: link:../../packages/core
@@ -50,52 +50,52 @@ importers:
         specifier: ^5.6.2
         version: 5.6.2
       commander:
-        specifier: ^14.0.2
-        version: 14.0.2
+        specifier: ^15.0.0
+        version: 15.0.0
       ora:
-        specifier: ^9.1.0
-        version: 9.1.0
+        specifier: ^9.4.0
+        version: 9.4.0
     devDependencies:
       "@lnai/typescript-config":
         specifier: workspace:*
         version: link:../../tooling/typescript-config
       "@types/node":
-        specifier: ^25.0.10
-        version: 25.0.10
+        specifier: ^25.9.3
+        version: 25.9.3
       eslint:
-        specifier: ^9.39.2
-        version: 9.39.2
+        specifier: ^10.4.1
+        version: 10.4.1
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.0.10)(yaml@2.8.2)
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
       "@astrojs/starlight":
-        specifier: ^0.37.4
-        version: 0.37.4(astro@5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2))
+        specifier: ^0.40.0
+        version: 0.40.0(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)
       astro:
-        specifier: ^5.16.15
-        version: 5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2)
+        specifier: ^6.4.6
+        version: 6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)
       sharp:
-        specifier: ^0.34.5
-        version: 0.34.5
+        specifier: ^0.35.1
+        version: 0.35.1
     devDependencies:
       "@lnai/typescript-config":
         specifier: workspace:*
         version: link:../../tooling/typescript-config
       eslint:
-        specifier: ^9.39.2
-        version: 9.39.2
+        specifier: ^10.4.1
+        version: 10.4.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/core:
     dependencies:
@@ -103,149 +103,159 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       "@lnai/typescript-config":
         specifier: workspace:*
         version: link:../../tooling/typescript-config
       "@types/node":
-        specifier: ^25.0.10
-        version: 25.0.10
+        specifier: ^25.9.3
+        version: 25.9.3
       eslint:
-        specifier: ^9.39.2
-        version: 9.39.2
+        specifier: ^10.4.1
+        version: 10.4.1
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@types/node@25.0.10)(yaml@2.8.2)
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
 
   tooling/eslint-config:
     dependencies:
       "@eslint/js":
-        specifier: ^9.39.0
-        version: 9.39.2
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.4.1)
       "@typescript-eslint/eslint-plugin":
-        specifier: ^8.53.1
-        version: 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
+        specifier: ^8.61.0
+        version: 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)
       "@typescript-eslint/parser":
-        specifier: ^8.53.1
-        version: 8.53.1(eslint@9.39.2)(typescript@5.9.3)
-      eslint:
-        specifier: ^9.0.0
-        version: 9.39.2
+        specifier: ^8.61.0
+        version: 8.61.0(eslint@10.4.1)(typescript@6.0.3)
       eslint-plugin-simple-import-sort:
-        specifier: ^12.1.1
-        version: 12.1.1(eslint@9.39.2)
+        specifier: ^13.0.0
+        version: 13.0.0(eslint@10.4.1)
       globals:
-        specifier: ^16.2.0
-        version: 16.5.0
+        specifier: ^17.6.0
+        version: 17.6.0
       typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
+        specifier: ^5.0.0 || ^6.0.0
+        version: 6.0.3
+    devDependencies:
+      eslint:
+        specifier: ^10.4.1
+        version: 10.4.1
 
   tooling/prettier-config:
     dependencies:
       prettier:
         specifier: ^3.0.0
-        version: 3.8.1
+        version: 3.8.4
+    devDependencies:
+      eslint:
+        specifier: ^10.4.1
+        version: 10.4.1
 
-  tooling/typescript-config: {}
+  tooling/typescript-config:
+    devDependencies:
+      eslint:
+        specifier: ^10.4.1
+        version: 10.4.1
 
 packages:
-  "@astrojs/compiler@2.13.0":
+  "@astrojs/compiler@4.0.0":
     resolution:
       {
-        integrity: sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==,
+        integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==,
       }
 
-  "@astrojs/internal-helpers@0.7.5":
+  "@astrojs/internal-helpers@0.10.0":
     resolution:
       {
-        integrity: sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==,
+        integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==,
       }
 
-  "@astrojs/markdown-remark@6.3.10":
+  "@astrojs/markdown-remark@7.2.0":
     resolution:
       {
-        integrity: sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==,
+        integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==,
       }
 
-  "@astrojs/mdx@4.3.13":
+  "@astrojs/mdx@6.0.3":
     resolution:
       {
-        integrity: sha512-IHDHVKz0JfKBy3//52JSiyWv089b7GVSChIXLrlUOoTLWowG3wr2/8hkaEgEyd/vysvNQvGk+QhysXpJW5ve6Q==,
+        integrity: sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
     peerDependencies:
-      astro: ^5.0.0
+      "@astrojs/markdown-satteri": 0.3.0
+      astro: ^6.4.0
+    peerDependenciesMeta:
+      "@astrojs/markdown-satteri":
+        optional: true
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.2":
     resolution:
       {
-        integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==,
+        integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
 
-  "@astrojs/sitemap@3.7.0":
+  "@astrojs/sitemap@3.7.3":
     resolution:
       {
-        integrity: sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==,
+        integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==,
       }
 
-  "@astrojs/starlight@0.37.4":
+  "@astrojs/starlight@0.40.0":
     resolution:
       {
-        integrity: sha512-ygPGDgRd9nCcNgaYMNN7UeAMAkDOR1ibv3ps3xEz+cuvKG3CRLd19UwdB+Gyz1tbkyfjPWPkFKNhLwNybro8Tw==,
+        integrity: sha512-H1NBIXx4Xw6YzKMsoMkazYxFgnTTj6pD4IReUGWj1fqw82AOAgj+WnZLpTDWRExf3b9ZM7Popbl583i4IvDNVQ==,
       }
     peerDependencies:
-      astro: ^5.5.0
+      "@astrojs/markdown-satteri": ^0.2.0
+      astro: ^6.4.5
+    peerDependenciesMeta:
+      "@astrojs/markdown-satteri":
+        optional: true
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.2":
     resolution:
       {
-        integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==,
+        integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==,
       }
     engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
-  "@babel/helper-string-parser@7.27.1":
+  "@babel/helper-string-parser@7.29.7":
     resolution:
       {
-        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+        integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-validator-identifier@7.28.5":
+  "@babel/helper-validator-identifier@7.29.7":
     resolution:
       {
-        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/parser@7.28.6":
+  "@babel/parser@7.29.7":
     resolution:
       {
-        integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==,
+        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
 
-  "@babel/runtime@7.28.6":
+  "@babel/types@7.29.7":
     resolution:
       {
-        integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/types@7.28.6":
-    resolution:
-      {
-        integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==,
+        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -256,6 +266,20 @@ packages:
       }
     engines: { node: ">=18" }
 
+  "@clack/core@1.4.1":
+    resolution:
+      {
+        integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==,
+      }
+    engines: { node: ">= 20.12.0" }
+
+  "@clack/prompts@1.5.1":
+    resolution:
+      {
+        integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==,
+      }
+    engines: { node: ">= 20.12.0" }
+
   "@ctrl/tinycolor@4.2.0":
     resolution:
       {
@@ -263,475 +287,241 @@ packages:
       }
     engines: { node: ">=14" }
 
-  "@emnapi/runtime@1.8.1":
+  "@emnapi/runtime@1.11.0":
     resolution:
       {
-        integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==,
+        integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==,
       }
 
-  "@esbuild/aix-ppc64@0.25.12":
+  "@esbuild/aix-ppc64@0.27.7":
     resolution:
       {
-        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [aix]
-
-  "@esbuild/aix-ppc64@0.27.2":
-    resolution:
-      {
-        integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==,
+        integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.12":
+  "@esbuild/android-arm64@0.27.7":
     resolution:
       {
-        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+        integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm64@0.27.2":
+  "@esbuild/android-arm@0.27.7":
     resolution:
       {
-        integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
+        integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-arm@0.27.2":
+  "@esbuild/android-x64@0.27.7":
     resolution:
       {
-        integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
-    os: [android]
-
-  "@esbuild/android-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+        integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  "@esbuild/android-x64@0.27.2":
+  "@esbuild/darwin-arm64@0.27.7":
     resolution:
       {
-        integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [android]
-
-  "@esbuild/darwin-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
+        integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-arm64@0.27.2":
+  "@esbuild/darwin-x64@0.27.7":
     resolution:
       {
-        integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+        integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.27.2":
+  "@esbuild/freebsd-arm64@0.27.7":
     resolution:
       {
-        integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [darwin]
-
-  "@esbuild/freebsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
+        integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-arm64@0.27.2":
+  "@esbuild/freebsd-x64@0.27.7":
     resolution:
       {
-        integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+        integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.27.2":
+  "@esbuild/linux-arm64@0.27.7":
     resolution:
       {
-        integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [freebsd]
-
-  "@esbuild/linux-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
+        integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm64@0.27.2":
+  "@esbuild/linux-arm@0.27.7":
     resolution:
       {
-        integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+        integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-arm@0.27.2":
+  "@esbuild/linux-ia32@0.27.7":
     resolution:
       {
-        integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
-    os: [linux]
-
-  "@esbuild/linux-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
+        integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
       }
     engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.27.2":
+  "@esbuild/linux-loong64@0.27.7":
     resolution:
       {
-        integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+        integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
       }
     engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.27.2":
+  "@esbuild/linux-mips64el@0.27.7":
     resolution:
       {
-        integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [loong64]
-    os: [linux]
-
-  "@esbuild/linux-mips64el@0.25.12":
-    resolution:
-      {
-        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
+        integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.27.2":
+  "@esbuild/linux-ppc64@0.27.7":
     resolution:
       {
-        integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [mips64el]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+        integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.27.2":
+  "@esbuild/linux-riscv64@0.27.7":
     resolution:
       {
-        integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [linux]
-
-  "@esbuild/linux-riscv64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
+        integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.27.2":
+  "@esbuild/linux-s390x@0.27.7":
     resolution:
       {
-        integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [riscv64]
-    os: [linux]
-
-  "@esbuild/linux-s390x@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+        integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
       }
     engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.27.2":
+  "@esbuild/linux-x64@0.27.7":
     resolution:
       {
-        integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [s390x]
-    os: [linux]
-
-  "@esbuild/linux-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
+        integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/linux-x64@0.27.2":
+  "@esbuild/netbsd-arm64@0.27.7":
     resolution:
       {
-        integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [linux]
-
-  "@esbuild/netbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+        integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-arm64@0.27.2":
+  "@esbuild/netbsd-x64@0.27.7":
     resolution:
       {
-        integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [netbsd]
-
-  "@esbuild/netbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
+        integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.27.2":
+  "@esbuild/openbsd-arm64@0.27.7":
     resolution:
       {
-        integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [netbsd]
-
-  "@esbuild/openbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+        integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-arm64@0.27.2":
+  "@esbuild/openbsd-x64@0.27.7":
     resolution:
       {
-        integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
+        integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.27.2":
+  "@esbuild/openharmony-arm64@0.27.7":
     resolution:
       {
-        integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [openbsd]
-
-  "@esbuild/openharmony-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+        integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/openharmony-arm64@0.27.2":
+  "@esbuild/sunos-x64@0.27.7":
     resolution:
       {
-        integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openharmony]
-
-  "@esbuild/sunos-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
+        integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/sunos-x64@0.27.2":
+  "@esbuild/win32-arm64@0.27.7":
     resolution:
       {
-        integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [sunos]
-
-  "@esbuild/win32-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+        integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-arm64@0.27.2":
+  "@esbuild/win32-ia32@0.27.7":
     resolution:
       {
-        integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [win32]
-
-  "@esbuild/win32-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
+        integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
       }
     engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.27.2":
+  "@esbuild/win32-x64@0.27.7":
     resolution:
       {
-        integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.27.2":
-    resolution:
-      {
-        integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==,
+        integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -753,90 +543,95 @@ packages:
       }
     engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
-  "@eslint/config-array@0.21.1":
+  "@eslint/config-array@0.23.5":
     resolution:
       {
-        integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==,
+        integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  "@eslint/config-helpers@0.4.2":
+  "@eslint/config-helpers@0.6.0":
     resolution:
       {
-        integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==,
+        integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  "@eslint/core@0.17.0":
+  "@eslint/core@1.2.1":
     resolution:
       {
-        integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==,
+        integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  "@eslint/eslintrc@3.3.3":
+  "@eslint/js@10.0.1":
     resolution:
       {
-        integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==,
+        integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
-  "@eslint/js@9.39.2":
+  "@eslint/object-schema@3.0.5":
     resolution:
       {
-        integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==,
+        integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  "@eslint/object-schema@2.1.7":
+  "@eslint/plugin-kit@0.7.2":
     resolution:
       {
-        integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==,
+        integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  "@eslint/plugin-kit@0.4.1":
+  "@expressive-code/core@0.43.1":
     resolution:
       {
-        integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@expressive-code/core@0.41.6":
-    resolution:
-      {
-        integrity: sha512-FvJQP+hG0jWi/FLBSmvHInDqWR7jNANp9PUDjdMqSshHb0y7sxx3vHuoOr6SgXjWw+MGLqorZyPQ0aAlHEok6g==,
+        integrity: sha512-H4rUJXKyS6y2q9Ig9bIp3dFhWhkZQIeH/jRGl3DROlslrGvfD4OC9qzmvKEFExm+/DtdvvHMQ8/Olmrcfxp+wQ==,
       }
 
-  "@expressive-code/plugin-frames@0.41.6":
+  "@expressive-code/plugin-frames@0.43.1":
     resolution:
       {
-        integrity: sha512-d+hkSYXIQot6fmYnOmWAM+7TNWRv/dhfjMsNq+mIZz8Tb4mPHOcgcfZeEM5dV9TDL0ioQNvtcqQNuzA1sRPjxg==,
+        integrity: sha512-tENfLw2UDeq5h749tTLvUtQYvgjIiQc6W7PBCR5xQ4yuE/QftManKJfUQjwJo6RRsAimVQDN4alhFTJ3aq1Khg==,
       }
 
-  "@expressive-code/plugin-shiki@0.41.6":
+  "@expressive-code/plugin-shiki@0.43.1":
     resolution:
       {
-        integrity: sha512-Y6zmKBmsIUtWTzdefqlzm/h9Zz0Rc4gNdt2GTIH7fhHH2I9+lDYCa27BDwuBhjqcos6uK81Aca9dLUC4wzN+ng==,
+        integrity: sha512-NdceinYEROXODNgB/ix+7oCdIg+nGyok+E+p2lU9YlWd1xKshXdXpmmptKfkuU27MJ5jjnfhMCI78YYBGi9GtQ==,
       }
 
-  "@expressive-code/plugin-text-markers@0.41.6":
+  "@expressive-code/plugin-text-markers@0.43.1":
     resolution:
       {
-        integrity: sha512-PBFa1wGyYzRExMDzBmAWC6/kdfG1oLn4pLpBeTfIRrALPjcGA/59HP3e7q9J0Smk4pC7U+lWkA2LHR8FYV8U7Q==,
+        integrity: sha512-JWf8wdbZSNoGY4TFv3lmt3/NNDaCP7iYL6rRYD05g8YYjKL62hKUHLl5+B47+v0+bqbuMhXDN7qz2wywFUvMkg==,
       }
 
-  "@humanfs/core@0.19.1":
+  "@humanfs/core@0.19.2":
     resolution:
       {
-        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+        integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==,
       }
     engines: { node: ">=18.18.0" }
 
-  "@humanfs/node@0.16.7":
+  "@humanfs/node@0.16.8":
     resolution:
       {
-        integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
+        integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==,
+      }
+    engines: { node: ">=18.18.0" }
+
+  "@humanfs/types@0.15.0":
+    resolution:
+      {
+        integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==,
       }
     engines: { node: ">=18.18.0" }
 
@@ -854,10 +649,10 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  "@img/colour@1.0.0":
+  "@img/colour@1.1.0":
     resolution:
       {
-        integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==,
+        integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
       }
     engines: { node: ">=18" }
 
@@ -870,6 +665,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  "@img/sharp-darwin-arm64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-T15JRWOubQ3f5+GxnWeIvo47u5qV0M9HBgJhT+f2gE1e9e6OhR6K73Re52Hm80qWcu1DNb3GweKmpr/MnuP2Ow==,
+      }
+    engines: { node: ">=20.9.0" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@img/sharp-darwin-x64@0.34.5":
     resolution:
       {
@@ -879,10 +683,35 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  "@img/sharp-darwin-x64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-t1CPD0cr7XCHjwUj6tQ5MC0pCi866I+gUW6zbUX4aFPnKd1DFBtk0M+gWcjX8VeEzgfCNiSiNTVFZ6b7kvdbnQ==,
+      }
+    engines: { node: ">=20.9.0" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@img/sharp-freebsd-wasm32@0.35.1":
+    resolution:
+      {
+        integrity: sha512-MBSQXqNPThW9EcZ905H6N4sEdX5EwZEYzGx5EBq9ncDCGJALMiY1xPFJxNdzuB1iBjLOpIfxajM6YxdvwmQSLA==,
+      }
+    engines: { node: ">=20.9.0" }
+    os: [freebsd]
+
   "@img/sharp-libvips-darwin-arm64@1.2.4":
     resolution:
       {
         integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@img/sharp-libvips-darwin-arm64@1.3.0":
+    resolution:
+      {
+        integrity: sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==,
       }
     cpu: [arm64]
     os: [darwin]
@@ -895,10 +724,26 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  "@img/sharp-libvips-darwin-x64@1.3.0":
+    resolution:
+      {
+        integrity: sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
   "@img/sharp-libvips-linux-arm64@1.2.4":
     resolution:
       {
         integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
+  "@img/sharp-libvips-linux-arm64@1.3.0":
+    resolution:
+      {
+        integrity: sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==,
       }
     cpu: [arm64]
     os: [linux]
@@ -911,10 +756,26 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  "@img/sharp-libvips-linux-arm@1.3.0":
+    resolution:
+      {
+        integrity: sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==,
+      }
+    cpu: [arm]
+    os: [linux]
+
   "@img/sharp-libvips-linux-ppc64@1.2.4":
     resolution:
       {
         integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@img/sharp-libvips-linux-ppc64@1.3.0":
+    resolution:
+      {
+        integrity: sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==,
       }
     cpu: [ppc64]
     os: [linux]
@@ -927,10 +788,26 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  "@img/sharp-libvips-linux-riscv64@1.3.0":
+    resolution:
+      {
+        integrity: sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+
   "@img/sharp-libvips-linux-s390x@1.2.4":
     resolution:
       {
         integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
+      }
+    cpu: [s390x]
+    os: [linux]
+
+  "@img/sharp-libvips-linux-s390x@1.3.0":
+    resolution:
+      {
+        integrity: sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==,
       }
     cpu: [s390x]
     os: [linux]
@@ -943,6 +820,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  "@img/sharp-libvips-linux-x64@1.3.0":
+    resolution:
+      {
+        integrity: sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==,
+      }
+    cpu: [x64]
+    os: [linux]
+
   "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
     resolution:
       {
@@ -951,10 +836,26 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@img/sharp-libvips-linuxmusl-arm64@1.3.0":
+    resolution:
+      {
+        integrity: sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
   "@img/sharp-libvips-linuxmusl-x64@1.2.4":
     resolution:
       {
         integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==,
+      }
+    cpu: [x64]
+    os: [linux]
+
+  "@img/sharp-libvips-linuxmusl-x64@1.3.0":
+    resolution:
+      {
+        integrity: sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==,
       }
     cpu: [x64]
     os: [linux]
@@ -968,12 +869,30 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@img/sharp-linux-arm64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-ErCRyGU7LeoaFBZ0xW8hhLlXzhAg80sc4vxePB86qvtEvW1jEhhmbiNBP4oEzZfPMnu6HwHXfzD2W2kBU+RnCw==,
+      }
+    engines: { node: ">=20.9.0" }
+    cpu: [arm64]
+    os: [linux]
+
   "@img/sharp-linux-arm@0.34.5":
     resolution:
       {
         integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==,
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@img/sharp-linux-arm@0.35.1":
+    resolution:
+      {
+        integrity: sha512-jygmR02PpCYypt7xB7nst1vqjZp/BpRA/Kf9nK7qRponJ/KrLPaZWEG4G15z1d2FZ6XqI+T0350ha3RSnKx24A==,
+      }
+    engines: { node: ">=20.9.0" }
     cpu: [arm]
     os: [linux]
 
@@ -986,12 +905,30 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  "@img/sharp-linux-ppc64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-LUWZ2+r2UoLCd8j0RLCwQ4gL6w47+Y7igxtVnPIDXOOEjV86LpBkAHq5VpJeg+GHbw0KN/JWlPJOdZjyZnFqFQ==,
+      }
+    engines: { node: ">=20.9.0" }
+    cpu: [ppc64]
+    os: [linux]
+
   "@img/sharp-linux-riscv64@0.34.5":
     resolution:
       {
         integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==,
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@img/sharp-linux-riscv64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-i7x6J3mwF4JgT0sM4V4WlAWdJ0bucPtA9rzO1bTji1n5qgBq/W5nn87RvOQPleuuxahNoLdTngByD8/vDDLArw==,
+      }
+    engines: { node: ">=20.9.0" }
     cpu: [riscv64]
     os: [linux]
 
@@ -1004,12 +941,30 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  "@img/sharp-linux-s390x@0.35.1":
+    resolution:
+      {
+        integrity: sha512-0zSaTUjTF0kIWTSYxD4EG/nvCU4jez53+3RdURtoY3HvbXtIQ98W90JnrGz/oLRFuEnfIy9+7xeq883euc0ZWw==,
+      }
+    engines: { node: ">=20.9.0" }
+    cpu: [s390x]
+    os: [linux]
+
   "@img/sharp-linux-x64@0.34.5":
     resolution:
       {
         integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==,
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@img/sharp-linux-x64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-NbJD4mWdeyrNQKluO/tR/wBDOelcowSVGNBWxI0e3ZtlXc6F/UOVKDj1MLD4zl3oHTuvKW3s+MA9N54YTldAYw==,
+      }
+    engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [linux]
 
@@ -1022,12 +977,30 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@img/sharp-linuxmusl-arm64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-VoW2sQCWI+0YIKQEmWJ8vzaQjTg9wIyfkFpvEfAS2h43X6iHu7GTk1hhOgB4IpSzCHe8UwQZIcx7b81VTaOrJA==,
+      }
+    engines: { node: ">=20.9.0" }
+    cpu: [arm64]
+    os: [linux]
+
   "@img/sharp-linuxmusl-x64@0.34.5":
     resolution:
       {
         integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==,
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@img/sharp-linuxmusl-x64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-LjBoSd/c5JU0/K5MwzDMlgsSRP2bPn98JQGFFQAOLQ0bU/1z4ekxUdSKY9BmlwSh/cA+OrvpgsWqfZyYfVHBRw==,
+      }
+    engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [linux]
 
@@ -1039,12 +1012,36 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [wasm32]
 
+  "@img/sharp-wasm32@0.35.1":
+    resolution:
+      {
+        integrity: sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==,
+      }
+    engines: { node: ">=20.9.0" }
+
+  "@img/sharp-webcontainers-wasm32@0.35.1":
+    resolution:
+      {
+        integrity: sha512-xU2ml2bU2OPxYVvW2A6ae4M1g5QKyhKG06P4FAt+YEaFQQO0919Qx+XxIZEUuWTMoDViLpMws2/dQwoe/VcA6A==,
+      }
+    engines: { node: ">=20.9.0" }
+    cpu: [wasm32]
+
   "@img/sharp-win32-arm64@0.34.5":
     resolution:
       {
         integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==,
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@img/sharp-win32-arm64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-IkmHwuFhYpd3bTsN5SAahjwhiAcyXPooBt8vEUgxY3T0IP70sSJ0nU1xiPzZY8AH/OB1XpV3j8aZSVSOSfTbdA==,
+      }
+    engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [win32]
 
@@ -1057,12 +1054,30 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  "@img/sharp-win32-ia32@0.35.1":
+    resolution:
+      {
+        integrity: sha512-wQahqCi9MD8Yxzg4gVM4fNrZxh+r6vD55PyIg+WJPaM5ZRUyF35iQpwJCuma3r6viU9/8Pxlc+XHV+woVa6nCQ==,
+      }
+    engines: { node: ^20.9.0 }
+    cpu: [ia32]
+    os: [win32]
+
   "@img/sharp-win32-x64@0.34.5":
     resolution:
       {
         integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==,
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@img/sharp-win32-x64@0.35.1":
+    resolution:
+      {
+        integrity: sha512-WzBtkYtZHATLPe8XRharxZXxQ9cdLrQWHiwxt+BJ5rBsisQrKeeV86ErxPSVhcG6xCEuNhs0SqLpWr7XDa2k6w==,
+      }
+    engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [win32]
 
@@ -1073,12 +1088,31 @@ packages:
       }
     engines: { node: ">=18" }
 
+  "@inquirer/ansi@2.0.7":
+    resolution:
+      {
+        integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+
   "@inquirer/checkbox@4.3.2":
     resolution:
       {
         integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==,
       }
     engines: { node: ">=18" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
+  "@inquirer/checkbox@5.2.1":
+    resolution:
+      {
+        integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
@@ -1097,12 +1131,36 @@ packages:
       "@types/node":
         optional: true
 
+  "@inquirer/confirm@6.1.1":
+    resolution:
+      {
+        integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
   "@inquirer/core@10.3.2":
     resolution:
       {
         integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==,
       }
     engines: { node: ">=18" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
+  "@inquirer/core@11.2.1":
+    resolution:
+      {
+        integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
@@ -1121,12 +1179,36 @@ packages:
       "@types/node":
         optional: true
 
+  "@inquirer/editor@5.2.2":
+    resolution:
+      {
+        integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
   "@inquirer/expand@4.0.23":
     resolution:
       {
         integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==,
       }
     engines: { node: ">=18" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
+  "@inquirer/expand@5.1.1":
+    resolution:
+      {
+        integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
@@ -1145,6 +1227,18 @@ packages:
       "@types/node":
         optional: true
 
+  "@inquirer/external-editor@3.0.3":
+    resolution:
+      {
+        integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
   "@inquirer/figures@1.0.15":
     resolution:
       {
@@ -1152,12 +1246,31 @@ packages:
       }
     engines: { node: ">=18" }
 
+  "@inquirer/figures@2.0.7":
+    resolution:
+      {
+        integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+
   "@inquirer/input@4.3.1":
     resolution:
       {
         integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==,
       }
     engines: { node: ">=18" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
+  "@inquirer/input@5.1.2":
+    resolution:
+      {
+        integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
@@ -1176,12 +1289,36 @@ packages:
       "@types/node":
         optional: true
 
+  "@inquirer/number@4.1.1":
+    resolution:
+      {
+        integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
   "@inquirer/password@4.0.23":
     resolution:
       {
         integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==,
       }
     engines: { node: ">=18" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
+  "@inquirer/password@5.1.1":
+    resolution:
+      {
+        integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
@@ -1200,12 +1337,36 @@ packages:
       "@types/node":
         optional: true
 
+  "@inquirer/prompts@8.5.2":
+    resolution:
+      {
+        integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
   "@inquirer/rawlist@4.1.11":
     resolution:
       {
         integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==,
       }
     engines: { node: ">=18" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
+  "@inquirer/rawlist@5.3.1":
+    resolution:
+      {
+        integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
@@ -1224,6 +1385,18 @@ packages:
       "@types/node":
         optional: true
 
+  "@inquirer/search@4.2.1":
+    resolution:
+      {
+        integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
   "@inquirer/select@4.4.2":
     resolution:
       {
@@ -1236,12 +1409,36 @@ packages:
       "@types/node":
         optional: true
 
+  "@inquirer/select@5.2.1":
+    resolution:
+      {
+        integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
   "@inquirer/type@3.0.10":
     resolution:
       {
         integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==,
       }
     engines: { node: ">=18" }
+    peerDependencies:
+      "@types/node": ">=18"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+
+  "@inquirer/type@4.0.7":
+    resolution:
+      {
+        integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==,
+      }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^20.17.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
@@ -1273,10 +1470,10 @@ packages:
         integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
       }
 
-  "@lnai/core@0.6.5":
+  "@lnai/core@0.6.91":
     resolution:
       {
-        integrity: sha512-xcaU56A0DhrEVxBtdJnzkezFv7PIsxA1xJ4raKczcAi/q5LTe8gY1Zan0yFnsaLM/VKSmgSZ+tgSk13E3SRSAA==,
+        integrity: sha512-NRM7NcOnPCT24gy08SvqlvLzDMgxxz6iuJmD+0fyU0z22bq6TBgLd5s23d5qfot+lUu8KVDz6ECLVzQ6zX+w/w==,
       }
 
   "@mdx-js/mdx@3.1.1":
@@ -1291,64 +1488,72 @@ packages:
         integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==,
       }
 
-  "@pagefind/darwin-arm64@1.4.0":
+  "@pagefind/darwin-arm64@1.5.2":
     resolution:
       {
-        integrity: sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==,
+        integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@pagefind/darwin-x64@1.4.0":
+  "@pagefind/darwin-x64@1.5.2":
     resolution:
       {
-        integrity: sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==,
+        integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@pagefind/default-ui@1.4.0":
+  "@pagefind/default-ui@1.5.2":
     resolution:
       {
-        integrity: sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ==,
+        integrity: sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==,
       }
 
-  "@pagefind/freebsd-x64@1.4.0":
+  "@pagefind/freebsd-x64@1.5.2":
     resolution:
       {
-        integrity: sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==,
+        integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==,
       }
     cpu: [x64]
     os: [freebsd]
 
-  "@pagefind/linux-arm64@1.4.0":
+  "@pagefind/linux-arm64@1.5.2":
     resolution:
       {
-        integrity: sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==,
+        integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@pagefind/linux-x64@1.4.0":
+  "@pagefind/linux-x64@1.5.2":
     resolution:
       {
-        integrity: sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==,
+        integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@pagefind/windows-x64@1.4.0":
+  "@pagefind/windows-arm64@1.5.2":
     resolution:
       {
-        integrity: sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==,
+        integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  "@pagefind/windows-x64@1.5.2":
+    resolution:
+      {
+        integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@rollup/pluginutils@5.3.0":
+  "@rollup/pluginutils@5.4.0":
     resolution:
       {
-        integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==,
+        integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==,
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
@@ -1357,241 +1562,254 @@ packages:
       rollup:
         optional: true
 
-  "@rollup/rollup-android-arm-eabi@4.56.0":
+  "@rollup/rollup-android-arm-eabi@4.61.1":
     resolution:
       {
-        integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==,
+        integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==,
       }
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.56.0":
+  "@rollup/rollup-android-arm64@4.61.1":
     resolution:
       {
-        integrity: sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==,
+        integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==,
       }
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.56.0":
+  "@rollup/rollup-darwin-arm64@4.61.1":
     resolution:
       {
-        integrity: sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==,
+        integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.56.0":
+  "@rollup/rollup-darwin-x64@4.61.1":
     resolution:
       {
-        integrity: sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==,
+        integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.56.0":
+  "@rollup/rollup-freebsd-arm64@4.61.1":
     resolution:
       {
-        integrity: sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==,
+        integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==,
       }
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.56.0":
+  "@rollup/rollup-freebsd-x64@4.61.1":
     resolution:
       {
-        integrity: sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==,
+        integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==,
       }
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.56.0":
+  "@rollup/rollup-linux-arm-gnueabihf@4.61.1":
     resolution:
       {
-        integrity: sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==,
+        integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==,
       }
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.56.0":
+  "@rollup/rollup-linux-arm-musleabihf@4.61.1":
     resolution:
       {
-        integrity: sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==,
+        integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==,
       }
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-gnu@4.56.0":
+  "@rollup/rollup-linux-arm64-gnu@4.61.1":
     resolution:
       {
-        integrity: sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==,
+        integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-musl@4.56.0":
+  "@rollup/rollup-linux-arm64-musl@4.61.1":
     resolution:
       {
-        integrity: sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==,
+        integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-gnu@4.56.0":
+  "@rollup/rollup-linux-loong64-gnu@4.61.1":
     resolution:
       {
-        integrity: sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==,
+        integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==,
       }
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-musl@4.56.0":
+  "@rollup/rollup-linux-loong64-musl@4.61.1":
     resolution:
       {
-        integrity: sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==,
+        integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==,
       }
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.56.0":
+  "@rollup/rollup-linux-ppc64-gnu@4.61.1":
     resolution:
       {
-        integrity: sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==,
+        integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==,
       }
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-musl@4.56.0":
+  "@rollup/rollup-linux-ppc64-musl@4.61.1":
     resolution:
       {
-        integrity: sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==,
+        integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==,
       }
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.56.0":
+  "@rollup/rollup-linux-riscv64-gnu@4.61.1":
     resolution:
       {
-        integrity: sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==,
+        integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==,
       }
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-musl@4.56.0":
+  "@rollup/rollup-linux-riscv64-musl@4.61.1":
     resolution:
       {
-        integrity: sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==,
+        integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==,
       }
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-s390x-gnu@4.56.0":
+  "@rollup/rollup-linux-s390x-gnu@4.61.1":
     resolution:
       {
-        integrity: sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==,
+        integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==,
       }
     cpu: [s390x]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-gnu@4.56.0":
+  "@rollup/rollup-linux-x64-gnu@4.61.1":
     resolution:
       {
-        integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==,
+        integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-musl@4.56.0":
+  "@rollup/rollup-linux-x64-musl@4.61.1":
     resolution:
       {
-        integrity: sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==,
+        integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-openbsd-x64@4.56.0":
+  "@rollup/rollup-openbsd-x64@4.61.1":
     resolution:
       {
-        integrity: sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==,
+        integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==,
       }
     cpu: [x64]
     os: [openbsd]
 
-  "@rollup/rollup-openharmony-arm64@4.56.0":
+  "@rollup/rollup-openharmony-arm64@4.61.1":
     resolution:
       {
-        integrity: sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==,
+        integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==,
       }
     cpu: [arm64]
     os: [openharmony]
 
-  "@rollup/rollup-win32-arm64-msvc@4.56.0":
+  "@rollup/rollup-win32-arm64-msvc@4.61.1":
     resolution:
       {
-        integrity: sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==,
+        integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==,
       }
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.56.0":
+  "@rollup/rollup-win32-ia32-msvc@4.61.1":
     resolution:
       {
-        integrity: sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==,
+        integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==,
       }
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-gnu@4.56.0":
+  "@rollup/rollup-win32-x64-gnu@4.61.1":
     resolution:
       {
-        integrity: sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==,
+        integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.56.0":
+  "@rollup/rollup-win32-x64-msvc@4.61.1":
     resolution:
       {
-        integrity: sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==,
+        integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@shikijs/core@3.21.0":
+  "@shikijs/core@4.2.0":
     resolution:
       {
-        integrity: sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA==,
+        integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/engine-javascript@3.21.0":
+  "@shikijs/engine-javascript@4.2.0":
     resolution:
       {
-        integrity: sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ==,
+        integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/engine-oniguruma@3.21.0":
+  "@shikijs/engine-oniguruma@4.2.0":
     resolution:
       {
-        integrity: sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==,
+        integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/langs@3.21.0":
+  "@shikijs/langs@4.2.0":
     resolution:
       {
-        integrity: sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==,
+        integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/themes@3.21.0":
+  "@shikijs/primitive@4.2.0":
     resolution:
       {
-        integrity: sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==,
+        integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/types@3.21.0":
+  "@shikijs/themes@4.2.0":
     resolution:
       {
-        integrity: sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==,
+        integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==,
       }
+    engines: { node: ">=20" }
+
+  "@shikijs/types@4.2.0":
+    resolution:
+      {
+        integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/vscode-textmate@10.0.2":
     resolution:
@@ -1605,16 +1823,64 @@ packages:
         integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
       }
 
+  "@turbo/darwin-64@2.9.18":
+    resolution:
+      {
+        integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  "@turbo/darwin-arm64@2.9.18":
+    resolution:
+      {
+        integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@turbo/linux-64@2.9.18":
+    resolution:
+      {
+        integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==,
+      }
+    cpu: [x64]
+    os: [linux]
+
+  "@turbo/linux-arm64@2.9.18":
+    resolution:
+      {
+        integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
+  "@turbo/windows-64@2.9.18":
+    resolution:
+      {
+        integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  "@turbo/windows-arm64@2.9.18":
+    resolution:
+      {
+        integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
   "@types/chai@5.2.3":
     resolution:
       {
         integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
       }
 
-  "@types/debug@4.1.12":
+  "@types/debug@4.1.13":
     resolution:
       {
-        integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==,
+        integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
       }
 
   "@types/deep-eql@4.0.2":
@@ -1623,16 +1889,22 @@ packages:
         integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
       }
 
+  "@types/esrecurse@4.3.1":
+    resolution:
+      {
+        integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==,
+      }
+
   "@types/estree-jsx@1.0.5":
     resolution:
       {
         integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
       }
 
-  "@types/estree@1.0.8":
+  "@types/estree@1.0.9":
     resolution:
       {
-        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+        integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
   "@types/hast@3.0.4":
@@ -1659,10 +1931,10 @@ packages:
         integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
       }
 
-  "@types/mdx@2.0.13":
+  "@types/mdx@2.0.14":
     resolution:
       {
-        integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
+        integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==,
       }
 
   "@types/ms@2.1.0":
@@ -1677,16 +1949,16 @@ packages:
         integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==,
       }
 
-  "@types/node@17.0.45":
+  "@types/node@24.13.2":
     resolution:
       {
-        integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==,
+        integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==,
       }
 
-  "@types/node@25.0.10":
+  "@types/node@25.9.3":
     resolution:
       {
-        integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==,
+        integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==,
       }
 
   "@types/sax@1.2.7":
@@ -1707,149 +1979,149 @@ packages:
         integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
       }
 
-  "@typescript-eslint/eslint-plugin@8.53.1":
+  "@typescript-eslint/eslint-plugin@8.61.0":
     resolution:
       {
-        integrity: sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==,
+        integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      "@typescript-eslint/parser": ^8.53.1
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: ">=4.8.4 <6.0.0"
+      "@typescript-eslint/parser": ^8.61.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/parser@8.53.1":
+  "@typescript-eslint/parser@8.61.0":
     resolution:
       {
-        integrity: sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==,
+        integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: ">=4.8.4 <6.0.0"
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/project-service@8.53.1":
+  "@typescript-eslint/project-service@8.61.0":
     resolution:
       {
-        integrity: sha512-WYC4FB5Ra0xidsmlPb+1SsnaSKPmS3gsjIARwbEkHkoWloQmuzcfypljaJcR78uyLA1h8sHdWWPHSLDI+MtNog==,
+        integrity: sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      typescript: ">=4.8.4 <6.0.0"
+      typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/scope-manager@8.53.1":
+  "@typescript-eslint/scope-manager@8.61.0":
     resolution:
       {
-        integrity: sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==,
+        integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  "@typescript-eslint/tsconfig-utils@8.53.1":
+  "@typescript-eslint/tsconfig-utils@8.61.0":
     resolution:
       {
-        integrity: sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.0.0"
-
-  "@typescript-eslint/type-utils@8.53.1":
-    resolution:
-      {
-        integrity: sha512-MOrdtNvyhy0rHyv0ENzub1d4wQYKb2NmIqG7qEqPWFW7Mpy2jzFC3pQ2yKDvirZB7jypm5uGjF2Qqs6OIqu47w==,
+        integrity: sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: ">=4.8.4 <6.0.0"
+      typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/types@8.53.1":
+  "@typescript-eslint/type-utils@8.61.0":
     resolution:
       {
-        integrity: sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/typescript-estree@8.53.1":
-    resolution:
-      {
-        integrity: sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==,
+        integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      typescript: ">=4.8.4 <6.0.0"
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/utils@8.53.1":
+  "@typescript-eslint/types@8.61.0":
     resolution:
       {
-        integrity: sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==,
+        integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/typescript-estree@8.61.0":
+    resolution:
+      {
+        integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: ">=4.8.4 <6.0.0"
+      typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/visitor-keys@8.53.1":
+  "@typescript-eslint/utils@8.61.0":
     resolution:
       {
-        integrity: sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==,
+        integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/visitor-keys@8.61.0":
+    resolution:
+      {
+        integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  "@ungap/structured-clone@1.3.0":
+  "@ungap/structured-clone@1.3.1":
     resolution:
       {
-        integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
+        integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==,
       }
 
-  "@vitest/expect@4.0.18":
+  "@vitest/expect@4.1.8":
     resolution:
       {
-        integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==,
+        integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==,
       }
 
-  "@vitest/mocker@4.0.18":
+  "@vitest/mocker@4.1.8":
     resolution:
       {
-        integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==,
+        integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==,
       }
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  "@vitest/pretty-format@4.0.18":
+  "@vitest/pretty-format@4.1.8":
     resolution:
       {
-        integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==,
+        integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==,
       }
 
-  "@vitest/runner@4.0.18":
+  "@vitest/runner@4.1.8":
     resolution:
       {
-        integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==,
+        integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==,
       }
 
-  "@vitest/snapshot@4.0.18":
+  "@vitest/snapshot@4.1.8":
     resolution:
       {
-        integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==,
+        integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==,
       }
 
-  "@vitest/spy@4.0.18":
+  "@vitest/spy@4.1.8":
     resolution:
       {
-        integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==,
+        integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==,
       }
 
-  "@vitest/utils@4.0.18":
+  "@vitest/utils@4.1.8":
     resolution:
       {
-        integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==,
+        integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==,
       }
 
   acorn-jsx@5.3.2:
@@ -1860,30 +2132,24 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.15.0:
+  acorn@8.17.0:
     resolution:
       {
-        integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
+        integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==,
       }
     engines: { node: ">=0.4.0" }
     hasBin: true
 
-  ajv@6.12.6:
+  ajv@6.15.0:
     resolution:
       {
-        integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+        integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==,
       }
 
-  ansi-align@3.0.1:
+  ansi-escapes@7.3.0:
     resolution:
       {
-        integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
-      }
-
-  ansi-escapes@7.2.0:
-    resolution:
-      {
-        integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==,
+        integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==,
       }
     engines: { node: ">=18" }
 
@@ -1973,21 +2239,20 @@ packages:
       }
     hasBin: true
 
-  astro-expressive-code@0.41.6:
+  astro-expressive-code@0.43.1:
     resolution:
       {
-        integrity: sha512-l47tb1uhmVIebHUkw+HEPtU/av0G4O8Q34g2cbkPvC7/e9ZhANcjUUciKt9Hp6gSVDdIuXBBLwJQn2LkeGMOAw==,
+        integrity: sha512-xddgwQxFRwpnnAnU7kSfrO82SsOAq7sQrYpXxVcrN9k/0aqNlTH2+mLrOMm1wXm6jdFKepst3hd8/qWojwuunw==,
       }
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@5.16.15:
+  astro@6.4.6:
     resolution:
       {
-        integrity: sha512-+X1Z0NTi2pa5a0Te6h77Dgc44fYj63j1yx6+39Nvg05lExajxSq7b1Uj/gtY45zoum8fD0+h0nak+DnHighs3A==,
+        integrity: sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==,
       }
-    engines:
-      { node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: ">=9.6.5", pnpm: ">=7.1.0" }
+    engines: { node: ">=22.12.0", npm: ">=9.6.5", pnpm: ">=7.1.0" }
     hasBin: true
 
   axobject-query@4.1.0:
@@ -2003,17 +2268,12 @@ packages:
         integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
       }
 
-  balanced-match@1.0.2:
+  balanced-match@4.0.4:
     resolution:
       {
-        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
       }
-
-  base-64@1.0.0:
-    resolution:
-      {
-        integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==,
-      }
+    engines: { node: 18 || 20 || >=22 }
 
   bcp-47-match@2.0.3:
     resolution:
@@ -2033,31 +2293,12 @@ packages:
         integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
       }
 
-  boxen@8.0.1:
+  brace-expansion@5.0.6:
     resolution:
       {
-        integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==,
+        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
       }
-    engines: { node: ">=18" }
-
-  brace-expansion@1.1.12:
-    resolution:
-      {
-        integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
-      }
-
-  brace-expansion@2.0.2:
-    resolution:
-      {
-        integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
-      }
-
-  braces@3.0.3:
-    resolution:
-      {
-        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
-      }
-    engines: { node: ">=8" }
+    engines: { node: 18 || 20 || >=22 }
 
   bundle-require@5.1.0:
     resolution:
@@ -2075,20 +2316,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  callsites@3.1.0:
-    resolution:
-      {
-        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
-      }
-    engines: { node: ">=6" }
-
-  camelcase@8.0.0:
-    resolution:
-      {
-        integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==,
-      }
-    engines: { node: ">=16" }
-
   ccount@2.0.1:
     resolution:
       {
@@ -2101,13 +2328,6 @@ packages:
         integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
       }
     engines: { node: ">=18" }
-
-  chalk@4.1.2:
-    resolution:
-      {
-        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-      }
-    engines: { node: ">=10" }
 
   chalk@5.6.2:
     resolution:
@@ -2160,19 +2380,12 @@ packages:
       }
     engines: { node: ">= 20.19.0" }
 
-  ci-info@4.3.1:
+  ci-info@4.4.0:
     resolution:
       {
-        integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==,
+        integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==,
       }
     engines: { node: ">=8" }
-
-  cli-boxes@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
-      }
-    engines: { node: ">=10" }
 
   cli-cursor@5.0.0:
     resolution:
@@ -2188,10 +2401,10 @@ packages:
       }
     engines: { node: ">=18.20" }
 
-  cli-truncate@5.1.1:
+  cli-truncate@5.2.0:
     resolution:
       {
-        integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==,
+        integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
       }
     engines: { node: ">=20" }
 
@@ -2228,12 +2441,6 @@ packages:
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
       }
 
-  colorette@2.0.20:
-    resolution:
-      {
-        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
-      }
-
   comma-separated-tokens@2.0.3:
     resolution:
       {
@@ -2247,12 +2454,19 @@ packages:
       }
     engines: { node: ">=16" }
 
-  commander@14.0.2:
+  commander@14.0.3:
     resolution:
       {
-        integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==,
+        integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
       }
     engines: { node: ">=20" }
+
+  commander@15.0.0:
+    resolution:
+      {
+        integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==,
+      }
+    engines: { node: ">=22.12.0" }
 
   commander@4.1.1:
     resolution:
@@ -2261,17 +2475,12 @@ packages:
       }
     engines: { node: ">= 6" }
 
-  common-ancestor-path@1.0.1:
+  common-ancestor-path@2.0.0:
     resolution:
       {
-        integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
+        integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==,
       }
-
-  concat-map@0.0.1:
-    resolution:
-      {
-        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
+    engines: { node: ">= 18" }
 
   confbox@0.1.8:
     resolution:
@@ -2286,10 +2495,16 @@ packages:
       }
     engines: { node: ^14.18.0 || >=16.10.0 }
 
-  cookie-es@1.2.2:
+  convert-source-map@2.0.0:
     resolution:
       {
-        integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==,
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
+
+  cookie-es@1.2.3:
+    resolution:
+      {
+        integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==,
       }
 
   cookie@1.1.1:
@@ -2331,10 +2546,10 @@ packages:
       }
     engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: ">=7.0.0" }
 
-  css-tree@3.1.0:
+  css-tree@3.2.1:
     resolution:
       {
-        integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==,
+        integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
       }
     engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
 
@@ -2384,10 +2599,10 @@ packages:
         integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
       }
 
-  defu@6.1.4:
+  defu@6.1.7:
     resolution:
       {
-        integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==,
+        integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==,
       }
 
   dequal@2.0.3:
@@ -2410,17 +2625,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  deterministic-object-hash@2.0.2:
+  devalue@5.8.1:
     resolution:
       {
-        integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==,
-      }
-    engines: { node: ">=18" }
-
-  devalue@5.6.2:
-    resolution:
-      {
-        integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==,
+        integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==,
       }
 
   devlop@1.1.0:
@@ -2429,10 +2637,10 @@ packages:
         integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
       }
 
-  diff@8.0.3:
+  diff@8.0.4:
     resolution:
       {
-        integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==,
+        integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==,
       }
     engines: { node: ">=0.3.1" }
 
@@ -2442,12 +2650,6 @@ packages:
         integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==,
       }
     hasBin: true
-
-  dlv@1.1.3:
-    resolution:
-      {
-        integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==,
-      }
 
   dom-serializer@2.0.0:
     resolution:
@@ -2514,10 +2716,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  es-module-lexer@1.7.0:
+  es-module-lexer@2.1.0:
     resolution:
       {
-        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
       }
 
   esast-util-from-estree@2.0.0:
@@ -2532,18 +2734,10 @@ packages:
         integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
       }
 
-  esbuild@0.25.12:
+  esbuild@0.27.7:
     resolution:
       {
-        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-      }
-    engines: { node: ">=18" }
-    hasBin: true
-
-  esbuild@0.27.2:
-    resolution:
-      {
-        integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==,
+        integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -2562,20 +2756,20 @@ packages:
       }
     engines: { node: ">=12" }
 
-  eslint-plugin-simple-import-sort@12.1.1:
+  eslint-plugin-simple-import-sort@13.0.0:
     resolution:
       {
-        integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==,
+        integrity: sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==,
       }
     peerDependencies:
       eslint: ">=5.0.0"
 
-  eslint-scope@8.4.0:
+  eslint-scope@9.1.2:
     resolution:
       {
-        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
+        integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   eslint-visitor-keys@3.4.3:
     resolution:
@@ -2584,19 +2778,19 @@ packages:
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
-  eslint-visitor-keys@4.2.1:
+  eslint-visitor-keys@5.0.1:
     resolution:
       {
-        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
+        integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  eslint@9.39.2:
+  eslint@10.4.1:
     resolution:
       {
-        integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==,
+        integrity: sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
     hasBin: true
     peerDependencies:
       jiti: "*"
@@ -2604,12 +2798,12 @@ packages:
       jiti:
         optional: true
 
-  espree@10.4.0:
+  espree@11.2.0:
     resolution:
       {
-        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+        integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==,
       }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   esprima@4.0.1:
     resolution:
@@ -2708,10 +2902,10 @@ packages:
       }
     engines: { node: ">=12.0.0" }
 
-  expressive-code@0.41.6:
+  expressive-code@0.43.1:
     resolution:
       {
-        integrity: sha512-W/5+IQbrpCIM5KGLjO35wlp1NCwDOOVQb+PAvzEoGkW1xjGM807ZGfBKptNWH6UECvt6qgmLyWolCMYKh7eQmA==,
+        integrity: sha512-JdOzanoU825iNvslmk6Kg8Ro61eSHmDK2Zz7BynOxObVrpIXZNzrIZOwQO2uDQcGsjSYShL/8vTrXgeWYnq3NA==,
       }
 
   extend-shallow@2.0.1:
@@ -2745,6 +2939,24 @@ packages:
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
       }
 
+  fast-string-truncated-width@3.0.3:
+    resolution:
+      {
+        integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==,
+      }
+
+  fast-string-width@3.0.2:
+    resolution:
+      {
+        integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==,
+      }
+
+  fast-wrap-ansi@0.2.2:
+    resolution:
+      {
+        integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==,
+      }
+
   fdir@6.5.0:
     resolution:
       {
@@ -2763,13 +2975,6 @@ packages:
         integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
       }
     engines: { node: ">=16.0.0" }
-
-  fill-range@7.1.1:
-    resolution:
-      {
-        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
-      }
-    engines: { node: ">=8" }
 
   find-up@5.0.0:
     resolution:
@@ -2791,10 +2996,10 @@ packages:
       }
     engines: { node: ">=16" }
 
-  flatted@3.3.3:
+  flatted@3.4.2:
     resolution:
       {
-        integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==,
+        integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
       }
 
   flattie@1.1.1:
@@ -2804,16 +3009,16 @@ packages:
       }
     engines: { node: ">=8" }
 
-  fontace@0.4.0:
+  fontace@0.4.1:
     resolution:
       {
-        integrity: sha512-moThBCItUe2bjZip5PF/iZClpKHGLwMvR79Kp8XpGRBrvoRSnySN4VcILdv3/MJzbhvUA5WeiUXF5o538m5fvg==,
+        integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==,
       }
 
-  fontkitten@1.0.2:
+  fontkitten@1.0.3:
     resolution:
       {
-        integrity: sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q==,
+        integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==,
       }
     engines: { node: ">=20" }
 
@@ -2825,12 +3030,19 @@ packages:
     engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
-  get-east-asian-width@1.4.0:
+  get-east-asian-width@1.6.0:
     resolution:
       {
-        integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==,
+        integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==,
       }
     engines: { node: ">=18" }
+
+  get-tsconfig@5.0.0-beta.4:
+    resolution:
+      {
+        integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==,
+      }
+    engines: { node: ">=20.20.0" }
 
   github-slugger@2.0.0:
     resolution:
@@ -2845,17 +3057,10 @@ packages:
       }
     engines: { node: ">=10.13.0" }
 
-  globals@14.0.0:
+  globals@17.6.0:
     resolution:
       {
-        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
-      }
-    engines: { node: ">=18" }
-
-  globals@16.5.0:
-    resolution:
-      {
-        integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==,
+        integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==,
       }
     engines: { node: ">=18" }
 
@@ -2866,18 +3071,11 @@ packages:
       }
     engines: { node: ">=6.0" }
 
-  h3@1.15.5:
+  h3@1.15.11:
     resolution:
       {
-        integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==,
+        integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==,
       }
-
-  has-flag@4.0.0:
-    resolution:
-      {
-        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-      }
-    engines: { node: ">=8" }
 
   hast-util-embedded@3.0.0:
     resolution:
@@ -3031,11 +3229,16 @@ packages:
     engines: { node: ">=18" }
     hasBin: true
 
-  i18next@23.16.8:
+  i18next@26.3.1:
     resolution:
       {
-        integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==,
+        integrity: sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==,
       }
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.7.2:
     resolution:
@@ -3057,19 +3260,6 @@ packages:
         integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
       }
     engines: { node: ">= 4" }
-
-  import-fresh@3.3.1:
-    resolution:
-      {
-        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
-      }
-    engines: { node: ">=6" }
-
-  import-meta-resolve@4.2.0:
-    resolution:
-      {
-        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
-      }
 
   imurmurhash@0.1.4:
     resolution:
@@ -3114,6 +3304,14 @@ packages:
         integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==,
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    hasBin: true
+
+  is-docker@4.0.0:
+    resolution:
+      {
+        integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==,
+      }
+    engines: { node: ">=20" }
     hasBin: true
 
   is-extendable@0.1.1:
@@ -3172,13 +3370,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  is-number@7.0.0:
-    resolution:
-      {
-        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
-      }
-    engines: { node: ">=0.12.0" }
-
   is-plain-obj@4.1.0:
     resolution:
       {
@@ -3193,10 +3384,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  is-wsl@3.1.0:
+  is-wsl@3.1.1:
     resolution:
       {
-        integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==,
+        integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==,
       }
     engines: { node: ">=16" }
 
@@ -3220,10 +3411,10 @@ packages:
       }
     hasBin: true
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     resolution:
       {
-        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+        integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==,
       }
     hasBin: true
 
@@ -3245,6 +3436,12 @@ packages:
         integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
       }
 
+  jsonc-parser@3.3.1:
+    resolution:
+      {
+        integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==,
+      }
+
   keyv@4.5.4:
     resolution:
       {
@@ -3257,13 +3454,6 @@ packages:
         integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
       }
     engines: { node: ">=0.10.0" }
-
-  kleur@3.0.3:
-    resolution:
-      {
-        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
-      }
-    engines: { node: ">=6" }
 
   klona@2.0.6:
     resolution:
@@ -3292,25 +3482,25 @@ packages:
         integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
       }
 
-  lint-staged@16.2.7:
+  lint-staged@17.0.7:
     resolution:
       {
-        integrity: sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==,
+        integrity: sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==,
       }
-    engines: { node: ">=20.17" }
+    engines: { node: ">=22.22.1" }
     hasBin: true
 
-  listr2@9.0.5:
+  listr2@10.2.1:
     resolution:
       {
-        integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==,
+        integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==,
       }
-    engines: { node: ">=20.0.0" }
+    engines: { node: ">=22.13.0" }
 
-  lnai@0.6.5:
+  lnai@0.6.91:
     resolution:
       {
-        integrity: sha512-W1y8ZcMhiETv1XZ85O6qpP08nQcF04puRkm4XVHJr15RwC8NNvFMY9BGXnhiZSuQkJ/VLGe6JQPK2sydo+qVRw==,
+        integrity: sha512-gHA1hDGTFSXxHOq369oNuAws6LRGEn98g711Ab7vT9pcQrbYDtKggj8zz38aiX7+iEy1Rj46VSrwtIqsDJlDhA==,
       }
     hasBin: true
 
@@ -3327,12 +3517,6 @@ packages:
         integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
       }
     engines: { node: ">=10" }
-
-  lodash.merge@4.6.2:
-    resolution:
-      {
-        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
-      }
 
   log-symbols@7.0.1:
     resolution:
@@ -3354,10 +3538,10 @@ packages:
         integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
       }
 
-  lru-cache@11.2.4:
+  lru-cache@11.5.1:
     resolution:
       {
-        integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==,
+        integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==,
       }
     engines: { node: 20 || >=22 }
 
@@ -3367,10 +3551,10 @@ packages:
         integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
       }
 
-  magicast@0.5.1:
+  magicast@0.5.3:
     resolution:
       {
-        integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==,
+        integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==,
       }
 
   markdown-extensions@2.0.0:
@@ -3404,10 +3588,10 @@ packages:
         integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==,
       }
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.3:
     resolution:
       {
-        integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==,
+        integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
       }
 
   mdast-util-gfm-autolink-literal@2.0.1:
@@ -3500,10 +3684,10 @@ packages:
         integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==,
       }
 
-  mdn-data@2.12.2:
+  mdn-data@2.27.1:
     resolution:
       {
-        integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==,
+        integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
       }
 
   micromark-core-commonmark@2.0.3:
@@ -3512,10 +3696,10 @@ packages:
         integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
       }
 
-  micromark-extension-directive@3.0.2:
+  micromark-extension-directive@4.0.0:
     resolution:
       {
-        integrity: sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==,
+        integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==,
       }
 
   micromark-extension-gfm-autolink-literal@2.1.0:
@@ -3722,13 +3906,6 @@ packages:
         integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==,
       }
 
-  micromatch@4.0.8:
-    resolution:
-      {
-        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
-      }
-    engines: { node: ">=8.6" }
-
   mimic-function@5.0.1:
     resolution:
       {
@@ -3736,23 +3913,17 @@ packages:
       }
     engines: { node: ">=18" }
 
-  minimatch@3.1.2:
+  minimatch@10.2.5:
     resolution:
       {
-        integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
+        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
       }
+    engines: { node: 18 || 20 || >=22 }
 
-  minimatch@9.0.5:
+  mlly@1.8.2:
     resolution:
       {
-        integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
-
-  mlly@1.8.0:
-    resolution:
-      {
-        integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==,
+        integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==,
       }
 
   mrmime@2.0.1:
@@ -3775,23 +3946,23 @@ packages:
       }
     engines: { node: ^18.17.0 || >=20.5.0 }
 
+  mute-stream@3.0.0:
+    resolution:
+      {
+        integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==,
+      }
+    engines: { node: ^20.17.0 || >=22.9.0 }
+
   mz@2.7.0:
     resolution:
       {
         integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
-  nano-spawn@2.0.0:
+  nanoid@3.3.12:
     resolution:
       {
-        integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==,
-      }
-    engines: { node: ">=20.17" }
-
-  nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -3847,11 +4018,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  obug@2.1.1:
+  obug@2.1.2:
     resolution:
       {
-        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+        integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==,
       }
+    engines: { node: ">=12.20.0" }
 
   ofetch@1.5.1:
     resolution:
@@ -3872,16 +4044,16 @@ packages:
       }
     engines: { node: ">=18" }
 
-  oniguruma-parser@0.12.1:
+  oniguruma-parser@0.12.2:
     resolution:
       {
-        integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==,
+        integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==,
       }
 
-  oniguruma-to-es@4.3.4:
+  oniguruma-to-es@4.3.6:
     resolution:
       {
-        integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==,
+        integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==,
       }
 
   optionator@0.9.4:
@@ -3891,10 +4063,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  ora@9.1.0:
+  ora@9.4.0:
     resolution:
       {
-        integrity: sha512-53uuLsXHOAJl5zLrUrzY9/kE+uIFEx7iaH4g2BIJQK4LZjY4LpCCYZVKDWIkL+F01wAaCg93duQ1whnK/AmY1A==,
+        integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==,
       }
     engines: { node: ">=20" }
 
@@ -3905,12 +4077,12 @@ packages:
       }
     engines: { node: ">=10" }
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     resolution:
       {
-        integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==,
+        integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
   p-locate@5.0.0:
     resolution:
@@ -3919,19 +4091,19 @@ packages:
       }
     engines: { node: ">=10" }
 
-  p-queue@8.1.1:
+  p-queue@9.3.0:
     resolution:
       {
-        integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==,
+        integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
-  p-timeout@6.1.4:
+  p-timeout@7.0.1:
     resolution:
       {
-        integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==,
+        integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==,
       }
-    engines: { node: ">=14.16" }
+    engines: { node: ">=20" }
 
   package-manager-detector@1.6.0:
     resolution:
@@ -3939,19 +4111,12 @@ packages:
         integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==,
       }
 
-  pagefind@1.4.0:
+  pagefind@1.5.2:
     resolution:
       {
-        integrity: sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==,
+        integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==,
       }
     hasBin: true
-
-  parent-module@1.0.1:
-    resolution:
-      {
-        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
-      }
-    engines: { node: ">=6" }
 
   parse-entities@4.0.2:
     resolution:
@@ -4003,27 +4168,19 @@ packages:
         integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
       }
 
-  picomatch@2.3.1:
+  picomatch@2.3.2:
     resolution:
       {
-        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
       }
     engines: { node: ">=8.6" }
 
-  picomatch@4.0.3:
+  picomatch@4.0.4:
     resolution:
       {
-        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: ">=12" }
-
-  pidtree@0.6.0:
-    resolution:
-      {
-        integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==,
-      }
-    engines: { node: ">=0.10" }
-    hasBin: true
 
   pirates@4.0.7:
     resolution:
@@ -4068,17 +4225,17 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
 
-  postcss-selector-parser@6.1.2:
+  postcss-selector-parser@6.1.4:
     resolution:
       {
-        integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==,
+        integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==,
       }
     engines: { node: ">=4" }
 
-  postcss@8.5.6:
+  postcss@8.5.15:
     resolution:
       {
-        integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
+        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -4089,10 +4246,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  prettier@3.8.1:
+  prettier@3.8.4:
     resolution:
       {
-        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
+        integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==,
       }
     engines: { node: ">=14" }
     hasBin: true
@@ -4104,17 +4261,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  prompts@2.4.2:
+  property-information@7.2.0:
     resolution:
       {
-        integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
-      }
-    engines: { node: ">= 6" }
-
-  property-information@7.1.0:
-    resolution:
-      {
-        integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
+        integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==,
       }
 
   punycode@2.3.1:
@@ -4188,10 +4338,10 @@ packages:
         integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==,
       }
 
-  rehype-expressive-code@0.41.6:
+  rehype-expressive-code@0.43.1:
     resolution:
       {
-        integrity: sha512-aBMX8kxPtjmDSFUdZlAWJkMvsQ4ZMASfee90JWIAV8tweltXLzkWC3q++43ToTelI8ac5iC0B3/S/Cl4Ql1y2g==,
+        integrity: sha512-CUOGQVlUcSMSXZgpcq9xL6B+dZqnI3w1R6EZj932XpGgj2Hmy7H6oMqa9W/Z7X2HOILWLWhqu1b9kuYcD+nd6w==,
       }
 
   rehype-format@5.0.1:
@@ -4230,10 +4380,10 @@ packages:
         integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==,
       }
 
-  remark-directive@3.0.1:
+  remark-directive@4.0.0:
     resolution:
       {
-        integrity: sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==,
+        integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==,
       }
 
   remark-gfm@4.0.1:
@@ -4273,19 +4423,18 @@ packages:
         integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
       }
 
-  resolve-from@4.0.0:
-    resolution:
-      {
-        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
-      }
-    engines: { node: ">=4" }
-
   resolve-from@5.0.0:
     resolution:
       {
         integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
       }
     engines: { node: ">=8" }
+
+  resolve-pkg-maps@1.0.0:
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
 
   restore-cursor@5.1.0:
     resolution:
@@ -4324,10 +4473,10 @@ packages:
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
 
-  rollup@4.56.0:
+  rollup@4.61.1:
     resolution:
       {
-        integrity: sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==,
+        integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==,
       }
     engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
@@ -4338,10 +4487,10 @@ packages:
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
 
-  sax@1.4.4:
+  sax@1.6.0:
     resolution:
       {
-        integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==,
+        integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==,
       }
     engines: { node: ">=11.0.0" }
 
@@ -4352,10 +4501,10 @@ packages:
       }
     engines: { node: ">=4" }
 
-  semver@7.7.3:
+  semver@7.8.4:
     resolution:
       {
-        integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==,
+        integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==,
       }
     engines: { node: ">=10" }
     hasBin: true
@@ -4366,6 +4515,13 @@ packages:
         integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==,
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+
+  sharp@0.35.1:
+    resolution:
+      {
+        integrity: sha512-lW979AMi+ESidzMv/Lnv+F9bknzLyxLqFI05Sm433vOeRcltgxQmXpnfOOFIAlKtwXU/ksupm2srQoFCkR214g==,
+      }
+    engines: { node: ">=20.9.0" }
 
   shebang-command@2.0.0:
     resolution:
@@ -4381,11 +4537,12 @@ packages:
       }
     engines: { node: ">=8" }
 
-  shiki@3.21.0:
+  shiki@4.2.0:
     resolution:
       {
-        integrity: sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==,
+        integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==,
       }
+    engines: { node: ">=20" }
 
   siginfo@2.0.0:
     resolution:
@@ -4406,12 +4563,12 @@ packages:
         integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
       }
 
-  sitemap@8.0.2:
+  sitemap@9.0.1:
     resolution:
       {
-        integrity: sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ==,
+        integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==,
       }
-    engines: { node: ">=14.0.0", npm: ">=6.0.0" }
+    engines: { node: ">=20.19.5", npm: ">=10.8.2" }
     hasBin: true
 
   slice-ansi@7.1.2:
@@ -4421,10 +4578,17 @@ packages:
       }
     engines: { node: ">=18" }
 
-  smol-toml@1.6.0:
+  slice-ansi@8.0.0:
     resolution:
       {
-        integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==,
+        integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
+      }
+    engines: { node: ">=20" }
+
+  smol-toml@1.6.1:
+    resolution:
+      {
+        integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==,
       }
     engines: { node: ">= 18" }
 
@@ -4460,16 +4624,16 @@ packages:
         integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
       }
 
-  std-env@3.10.0:
+  std-env@4.1.0:
     resolution:
       {
-        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
+        integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
       }
 
-  stdin-discarder@0.2.2:
+  stdin-discarder@0.3.2:
     resolution:
       {
-        integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==,
+        integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==,
       }
     engines: { node: ">=18" }
 
@@ -4500,10 +4664,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  string-width@8.1.0:
+  string-width@8.2.1:
     resolution:
       {
-        integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==,
+        integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==,
       }
     engines: { node: ">=20" }
 
@@ -4520,10 +4684,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  strip-ansi@7.1.2:
+  strip-ansi@7.2.0:
     resolution:
       {
-        integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==,
+        integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
       }
     engines: { node: ">=12" }
 
@@ -4533,13 +4697,6 @@ packages:
         integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==,
       }
     engines: { node: ">=0.10.0" }
-
-  strip-json-comments@3.1.1:
-    resolution:
-      {
-        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
-      }
-    engines: { node: ">=8" }
 
   style-to-js@1.1.21:
     resolution:
@@ -4561,17 +4718,10 @@ packages:
     engines: { node: ">=16 || 14 >=14.17" }
     hasBin: true
 
-  supports-color@7.2.0:
+  svgo@4.0.1:
     resolution:
       {
-        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-      }
-    engines: { node: ">=8" }
-
-  svgo@4.0.0:
-    resolution:
-      {
-        integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==,
+        integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==,
       }
     engines: { node: ">=16" }
     hasBin: true
@@ -4601,39 +4751,39 @@ packages:
         integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
       }
 
+  tinyclip@0.1.14:
+    resolution:
+      {
+        integrity: sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==,
+      }
+    engines: { node: ^16.14.0 || >= 17.3.0 }
+
   tinyexec@0.3.2:
     resolution:
       {
         integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
       }
 
-  tinyexec@1.0.2:
+  tinyexec@1.2.4:
     resolution:
       {
-        integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==,
+        integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
       }
     engines: { node: ">=18" }
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.17:
     resolution:
       {
-        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
       }
     engines: { node: ">=12.0.0" }
 
-  tinyrainbow@3.0.3:
+  tinyrainbow@3.1.0:
     resolution:
       {
-        integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==,
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
       }
     engines: { node: ">=14.0.0" }
-
-  to-regex-range@5.0.1:
-    resolution:
-      {
-        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
-      }
-    engines: { node: ">=8.0" }
 
   tree-kill@1.2.2:
     resolution:
@@ -4654,10 +4804,10 @@ packages:
         integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
       }
 
-  ts-api-utils@2.4.0:
+  ts-api-utils@2.5.0:
     resolution:
       {
-        integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==,
+        integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==,
       }
     engines: { node: ">=18.12" }
     peerDependencies:
@@ -4668,19 +4818,6 @@ packages:
       {
         integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
       }
-
-  tsconfck@3.1.6:
-    resolution:
-      {
-        integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
-      }
-    engines: { node: ^18 || >=20 }
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   tslib@2.8.1:
     resolution:
@@ -4710,58 +4847,10 @@ packages:
       typescript:
         optional: true
 
-  turbo-darwin-64@2.7.6:
+  turbo@2.9.18:
     resolution:
       {
-        integrity: sha512-bYu0qnWju2Ha3EbIkPCk1SMLT3sltKh1P/Jy5FER6BmH++H5z+T5MHh3W1Xoers9rk4N1VdKvog9FO1pxQyjhw==,
-      }
-    cpu: [x64]
-    os: [darwin]
-
-  turbo-darwin-arm64@2.7.6:
-    resolution:
-      {
-        integrity: sha512-KCxTf3Y1hgNLYIWRLw8bwH8Zie9RyCGoxAlXYsCBI/YNqBSR+ZZK9KYzFxAqDaVaNvTwLFv3rJRGsXOFWg4+Uw==,
-      }
-    cpu: [arm64]
-    os: [darwin]
-
-  turbo-linux-64@2.7.6:
-    resolution:
-      {
-        integrity: sha512-vjoU8zIfNgvJR3cMitgw7inEoi6bmuVuFawDl5yKtxjAEhDktFdRBpGS3WojD4l3BklBbIK689ssXcGf21LxRA==,
-      }
-    cpu: [x64]
-    os: [linux]
-
-  turbo-linux-arm64@2.7.6:
-    resolution:
-      {
-        integrity: sha512-TcMpBvTqZf+1DptrVYLbZls7WY1UVNDTGaf0bo7/GCgWYv5eZHCVo4Td7kCJeDU4glbXg67REX0md0S0V6ghMg==,
-      }
-    cpu: [arm64]
-    os: [linux]
-
-  turbo-windows-64@2.7.6:
-    resolution:
-      {
-        integrity: sha512-1/MhkYldiihjneY8QnnDMbAkHXn/udTWSVYS94EMlkE9AShozsLTTOT1gDOpX06EfEW5njP09suhMvxbvwuwpQ==,
-      }
-    cpu: [x64]
-    os: [win32]
-
-  turbo-windows-arm64@2.7.6:
-    resolution:
-      {
-        integrity: sha512-0wDVnUJLFAWm4ZzOQFDkbyyUqaszorTGf3Rdc22IRIyJTTLd6ajqdb+cWD89UZ1RKr953+PZR1gqgWQY4PDuhA==,
-      }
-    cpu: [arm64]
-    os: [win32]
-
-  turbo@2.7.6:
-    resolution:
-      {
-        integrity: sha512-PO9AvJLEsNLO+EYhF4zB+v10hOjsJe5kJW+S6tTbRv+TW7gf1Qer4mfjP9h3/y9h8ZiPvOrenxnEgDtFgaM5zw==,
+        integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==,
       }
     hasBin: true
 
@@ -4772,25 +4861,18 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  type-fest@4.41.0:
+  typescript@6.0.3:
     resolution:
       {
-        integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
-      }
-    engines: { node: ">=16" }
-
-  typescript@5.9.3:
-    resolution:
-      {
-        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+        integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==,
       }
     engines: { node: ">=14.17" }
     hasBin: true
 
-  ufo@1.6.3:
+  ufo@1.6.4:
     resolution:
       {
-        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
+        integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==,
       }
 
   ultrahtml@1.6.0:
@@ -4805,10 +4887,16 @@ packages:
         integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==,
       }
 
-  undici-types@7.16.0:
+  undici-types@7.18.2:
     resolution:
       {
-        integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
+        integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
+      }
+
+  undici-types@7.24.6:
+    resolution:
+      {
+        integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==,
       }
 
   unified@11.0.5:
@@ -4817,10 +4905,10 @@ packages:
         integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
       }
 
-  unifont@0.7.3:
+  unifont@0.7.4:
     resolution:
       {
-        integrity: sha512-b0GtQzKCyuSHGsfj5vyN8st7muZ6VCI4XD4vFlr7Uy1rlWVYxC3npnfk8MyreHxJYrz1ooLDqDzFe9XqQTlAhA==,
+        integrity: sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==,
       }
 
   unist-util-find-after@5.0.0:
@@ -4883,10 +4971,10 @@ packages:
         integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
       }
 
-  unstorage@1.17.4:
+  unstorage@1.17.5:
     resolution:
       {
-        integrity: sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==,
+        integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==,
       }
     peerDependencies:
       "@azure/app-configuration": ^1.8.0
@@ -4978,22 +5066,22 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
-  vite@6.4.1:
+  vite@7.3.5:
     resolution:
       {
-        integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==,
+        integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==,
       }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      "@types/node": ^20.19.0 || >=22.12.0
       jiti: ">=1.21.0"
-      less: "*"
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -5021,21 +5109,21 @@ packages:
       yaml:
         optional: true
 
-  vitefu@1.1.1:
+  vitefu@1.1.3:
     resolution:
       {
-        integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==,
+        integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==,
       }
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
         optional: true
 
-  vitest@4.0.18:
+  vitest@4.1.8:
     resolution:
       {
-        integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==,
+        integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==,
       }
     engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
@@ -5043,12 +5131,15 @@ packages:
       "@edge-runtime/vm": "*"
       "@opentelemetry/api": ^1.9.0
       "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-      "@vitest/browser-playwright": 4.0.18
-      "@vitest/browser-preview": 4.0.18
-      "@vitest/browser-webdriverio": 4.0.18
-      "@vitest/ui": 4.0.18
+      "@vitest/browser-playwright": 4.1.8
+      "@vitest/browser-preview": 4.1.8
+      "@vitest/browser-webdriverio": 4.1.8
+      "@vitest/coverage-istanbul": 4.1.8
+      "@vitest/coverage-v8": 4.1.8
+      "@vitest/ui": 4.1.8
       happy-dom: "*"
       jsdom: "*"
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       "@edge-runtime/vm":
         optional: true
@@ -5061,6 +5152,10 @@ packages:
       "@vitest/browser-preview":
         optional: true
       "@vitest/browser-webdriverio":
+        optional: true
+      "@vitest/coverage-istanbul":
+        optional: true
+      "@vitest/coverage-v8":
         optional: true
       "@vitest/ui":
         optional: true
@@ -5098,19 +5193,19 @@ packages:
     engines: { node: ">=8" }
     hasBin: true
 
-  widest-line@5.0.0:
-    resolution:
-      {
-        integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==,
-      }
-    engines: { node: ">=18" }
-
   word-wrap@1.2.5:
     resolution:
       {
         integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
       }
     engines: { node: ">=0.10.0" }
+
+  wrap-ansi@10.0.0:
+    resolution:
+      {
+        integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==,
+      }
+    engines: { node: ">=20" }
 
   wrap-ansi@6.2.0:
     resolution:
@@ -5132,20 +5227,20 @@ packages:
         integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==,
       }
 
-  yaml@2.8.2:
+  yaml@2.9.0:
     resolution:
       {
-        integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==,
+        integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==,
       }
     engines: { node: ">= 14.6" }
     hasBin: true
 
-  yargs-parser@21.1.1:
+  yargs-parser@22.0.0:
     resolution:
       {
-        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+        integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
       }
-    engines: { node: ">=12" }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
 
   yocto-queue@0.1.0:
     resolution:
@@ -5161,13 +5256,6 @@ packages:
       }
     engines: { node: ">=12.20" }
 
-  yocto-spinner@0.2.3:
-    resolution:
-      {
-        integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==,
-      }
-    engines: { node: ">=18.19" }
-
   yoctocolors-cjs@2.1.3:
     resolution:
       {
@@ -5182,33 +5270,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  zod-to-json-schema@3.25.1:
+  zod@4.4.3:
     resolution:
       {
-        integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==,
-      }
-    peerDependencies:
-      zod: ^3.25 || ^4
-
-  zod-to-ts@1.2.0:
-    resolution:
-      {
-        integrity: sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==,
-      }
-    peerDependencies:
-      typescript: ^4.9.4 || ^5.0.2
-      zod: ^3
-
-  zod@3.25.76:
-    resolution:
-      {
-        integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
-      }
-
-  zod@4.3.6:
-    resolution:
-      {
-        integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
+        integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
       }
 
   zwitch@2.0.4:
@@ -5218,19 +5283,26 @@ packages:
       }
 
 snapshots:
-  "@astrojs/compiler@2.13.0": {}
+  "@astrojs/compiler@4.0.0": {}
 
-  "@astrojs/internal-helpers@0.7.5": {}
-
-  "@astrojs/markdown-remark@6.3.10":
+  "@astrojs/internal-helpers@0.10.0":
     dependencies:
-      "@astrojs/internal-helpers": 0.7.5
-      "@astrojs/prism": 3.3.0
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      js-yaml: 4.2.0
+      picomatch: 4.0.4
+      retext-smartypants: 6.2.0
+      shiki: 4.2.0
+      smol-toml: 1.6.1
+      unified: 11.0.5
+
+  "@astrojs/markdown-remark@7.2.0":
+    dependencies:
+      "@astrojs/internal-helpers": 0.10.0
+      "@astrojs/prism": 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      import-meta-resolve: 4.2.0
-      js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -5238,8 +5310,6 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      shiki: 3.21.0
-      smol-toml: 1.6.0
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -5248,13 +5318,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@4.3.13(astro@5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2))":
+  "@astrojs/mdx@6.0.3(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))":
     dependencies:
-      "@astrojs/markdown-remark": 6.3.10
+      "@astrojs/internal-helpers": 0.10.0
+      "@astrojs/markdown-remark": 7.2.0
       "@mdx-js/mdx": 3.1.1
-      acorn: 8.15.0
-      astro: 5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2)
-      es-module-lexer: 1.7.0
+      acorn: 8.17.0
+      astro: 6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)
+      es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
@@ -5267,331 +5338,258 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.2":
     dependencies:
       prismjs: 1.30.0
 
-  "@astrojs/sitemap@3.7.0":
+  "@astrojs/sitemap@3.7.3":
     dependencies:
-      sitemap: 8.0.2
+      sitemap: 9.0.1
       stream-replace-string: 2.0.0
-      zod: 3.25.76
+      zod: 4.4.3
 
-  "@astrojs/starlight@0.37.4(astro@5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2))":
+  "@astrojs/starlight@0.40.0(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))(typescript@6.0.3)":
     dependencies:
-      "@astrojs/markdown-remark": 6.3.10
-      "@astrojs/mdx": 4.3.13(astro@5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2))
-      "@astrojs/sitemap": 3.7.0
-      "@pagefind/default-ui": 1.4.0
+      "@astrojs/markdown-remark": 7.2.0
+      "@astrojs/mdx": 6.0.3(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))
+      "@astrojs/sitemap": 3.7.3
+      "@pagefind/default-ui": 1.5.2
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2)
-      astro-expressive-code: 0.41.6(astro@5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2))
+      astro: 6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)
+      astro-expressive-code: 0.43.1(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
-      i18next: 23.16.8
-      js-yaml: 4.1.1
+      i18next: 26.3.1(typescript@6.0.3)
+      js-yaml: 4.2.0
       klona: 2.0.6
       magic-string: 0.30.21
       mdast-util-directive: 3.1.0
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
-      pagefind: 1.4.0
+      pagefind: 1.5.2
       rehype: 13.0.2
       rehype-format: 5.0.1
-      remark-directive: 3.0.1
+      remark-directive: 4.0.0
       ultrahtml: 1.6.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+      - typescript
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.2":
     dependencies:
-      ci-info: 4.3.1
-      debug: 4.4.3
-      dlv: 1.1.3
+      ci-info: 4.4.0
       dset: 3.1.4
-      is-docker: 3.0.0
-      is-wsl: 3.1.0
+      is-docker: 4.0.0
+      is-wsl: 3.1.1
       which-pm-runs: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
 
-  "@babel/helper-string-parser@7.27.1": {}
+  "@babel/helper-string-parser@7.29.7": {}
 
-  "@babel/helper-validator-identifier@7.28.5": {}
+  "@babel/helper-validator-identifier@7.29.7": {}
 
-  "@babel/parser@7.28.6":
+  "@babel/parser@7.29.7":
     dependencies:
-      "@babel/types": 7.28.6
+      "@babel/types": 7.29.7
 
-  "@babel/runtime@7.28.6": {}
-
-  "@babel/types@7.28.6":
+  "@babel/types@7.29.7":
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
+      "@babel/helper-string-parser": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
 
   "@capsizecss/unpack@4.0.0":
     dependencies:
-      fontkitten: 1.0.2
+      fontkitten: 1.0.3
+
+  "@clack/core@1.4.1":
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  "@clack/prompts@1.5.1":
+    dependencies:
+      "@clack/core": 1.4.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   "@ctrl/tinycolor@4.2.0": {}
 
-  "@emnapi/runtime@1.8.1":
+  "@emnapi/runtime@1.11.0":
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  "@esbuild/aix-ppc64@0.25.12":
+  "@esbuild/aix-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/aix-ppc64@0.27.2":
+  "@esbuild/android-arm64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm64@0.25.12":
+  "@esbuild/android-arm@0.27.7":
     optional: true
 
-  "@esbuild/android-arm64@0.27.2":
+  "@esbuild/android-x64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm@0.25.12":
+  "@esbuild/darwin-arm64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm@0.27.2":
+  "@esbuild/darwin-x64@0.27.7":
     optional: true
 
-  "@esbuild/android-x64@0.25.12":
+  "@esbuild/freebsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/android-x64@0.27.2":
+  "@esbuild/freebsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-arm64@0.25.12":
+  "@esbuild/linux-arm64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-arm64@0.27.2":
+  "@esbuild/linux-arm@0.27.7":
     optional: true
 
-  "@esbuild/darwin-x64@0.25.12":
+  "@esbuild/linux-ia32@0.27.7":
     optional: true
 
-  "@esbuild/darwin-x64@0.27.2":
+  "@esbuild/linux-loong64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.25.12":
+  "@esbuild/linux-mips64el@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.27.2":
+  "@esbuild/linux-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-x64@0.25.12":
+  "@esbuild/linux-riscv64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-x64@0.27.2":
+  "@esbuild/linux-s390x@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm64@0.25.12":
+  "@esbuild/linux-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm64@0.27.2":
+  "@esbuild/netbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm@0.25.12":
+  "@esbuild/netbsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm@0.27.2":
+  "@esbuild/openbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/linux-ia32@0.25.12":
+  "@esbuild/openbsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-ia32@0.27.2":
+  "@esbuild/openharmony-arm64@0.27.7":
     optional: true
 
-  "@esbuild/linux-loong64@0.25.12":
+  "@esbuild/sunos-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-loong64@0.27.2":
+  "@esbuild/win32-arm64@0.27.7":
     optional: true
 
-  "@esbuild/linux-mips64el@0.25.12":
+  "@esbuild/win32-ia32@0.27.7":
     optional: true
 
-  "@esbuild/linux-mips64el@0.27.2":
+  "@esbuild/win32-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-ppc64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.27.2":
-    optional: true
-
-  "@esbuild/linux-riscv64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-riscv64@0.27.2":
-    optional: true
-
-  "@esbuild/linux-s390x@0.25.12":
-    optional: true
-
-  "@esbuild/linux-s390x@0.27.2":
-    optional: true
-
-  "@esbuild/linux-x64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-x64@0.27.2":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.27.2":
-    optional: true
-
-  "@esbuild/netbsd-x64@0.25.12":
-    optional: true
-
-  "@esbuild/netbsd-x64@0.27.2":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.27.2":
-    optional: true
-
-  "@esbuild/openbsd-x64@0.25.12":
-    optional: true
-
-  "@esbuild/openbsd-x64@0.27.2":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.27.2":
-    optional: true
-
-  "@esbuild/sunos-x64@0.25.12":
-    optional: true
-
-  "@esbuild/sunos-x64@0.27.2":
-    optional: true
-
-  "@esbuild/win32-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/win32-arm64@0.27.2":
-    optional: true
-
-  "@esbuild/win32-ia32@0.25.12":
-    optional: true
-
-  "@esbuild/win32-ia32@0.27.2":
-    optional: true
-
-  "@esbuild/win32-x64@0.25.12":
-    optional: true
-
-  "@esbuild/win32-x64@0.27.2":
-    optional: true
-
-  "@eslint-community/eslint-utils@4.9.1(eslint@9.39.2)":
+  "@eslint-community/eslint-utils@4.9.1(eslint@10.4.1)":
     dependencies:
-      eslint: 9.39.2
+      eslint: 10.4.1
       eslint-visitor-keys: 3.4.3
 
   "@eslint-community/regexpp@4.12.2": {}
 
-  "@eslint/config-array@0.21.1":
+  "@eslint/config-array@0.23.5":
     dependencies:
-      "@eslint/object-schema": 2.1.7
+      "@eslint/object-schema": 3.0.5
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
-  "@eslint/config-helpers@0.4.2":
+  "@eslint/config-helpers@0.6.0":
     dependencies:
-      "@eslint/core": 0.17.0
+      "@eslint/core": 1.2.1
 
-  "@eslint/core@0.17.0":
+  "@eslint/core@1.2.1":
     dependencies:
       "@types/json-schema": 7.0.15
 
-  "@eslint/eslintrc@3.3.3":
+  "@eslint/js@10.0.1(eslint@10.4.1)":
+    optionalDependencies:
+      eslint: 10.4.1
+
+  "@eslint/object-schema@3.0.5": {}
+
+  "@eslint/plugin-kit@0.7.2":
     dependencies:
-      ajv: 6.12.6
-      debug: 4.4.3
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  "@eslint/js@9.39.2": {}
-
-  "@eslint/object-schema@2.1.7": {}
-
-  "@eslint/plugin-kit@0.4.1":
-    dependencies:
-      "@eslint/core": 0.17.0
+      "@eslint/core": 1.2.1
       levn: 0.4.1
 
-  "@expressive-code/core@0.41.6":
+  "@expressive-code/core@0.43.1":
     dependencies:
       "@ctrl/tinycolor": 4.2.0
       hast-util-select: 6.0.4
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.6
-      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss: 8.5.15
+      postcss-nested: 6.2.0(postcss@8.5.15)
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
-  "@expressive-code/plugin-frames@0.41.6":
+  "@expressive-code/plugin-frames@0.43.1":
     dependencies:
-      "@expressive-code/core": 0.41.6
+      "@expressive-code/core": 0.43.1
 
-  "@expressive-code/plugin-shiki@0.41.6":
+  "@expressive-code/plugin-shiki@0.43.1":
     dependencies:
-      "@expressive-code/core": 0.41.6
-      shiki: 3.21.0
+      "@expressive-code/core": 0.43.1
+      shiki: 4.2.0
 
-  "@expressive-code/plugin-text-markers@0.41.6":
+  "@expressive-code/plugin-text-markers@0.43.1":
     dependencies:
-      "@expressive-code/core": 0.41.6
+      "@expressive-code/core": 0.43.1
 
-  "@humanfs/core@0.19.1": {}
-
-  "@humanfs/node@0.16.7":
+  "@humanfs/core@0.19.2":
     dependencies:
-      "@humanfs/core": 0.19.1
+      "@humanfs/types": 0.15.0
+
+  "@humanfs/node@0.16.8":
+    dependencies:
+      "@humanfs/core": 0.19.2
+      "@humanfs/types": 0.15.0
       "@humanwhocodes/retry": 0.4.3
+
+  "@humanfs/types@0.15.0": {}
 
   "@humanwhocodes/module-importer@1.0.1": {}
 
   "@humanwhocodes/retry@0.4.3": {}
 
-  "@img/colour@1.0.0": {}
+  "@img/colour@1.1.0": {}
 
   "@img/sharp-darwin-arm64@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-darwin-arm64": 1.2.4
+    optional: true
+
+  "@img/sharp-darwin-arm64@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-darwin-arm64": 1.3.0
     optional: true
 
   "@img/sharp-darwin-x64@0.34.5":
@@ -5599,34 +5597,74 @@ snapshots:
       "@img/sharp-libvips-darwin-x64": 1.2.4
     optional: true
 
+  "@img/sharp-darwin-x64@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-darwin-x64": 1.3.0
+    optional: true
+
+  "@img/sharp-freebsd-wasm32@0.35.1":
+    dependencies:
+      "@img/sharp-wasm32": 0.35.1
+    optional: true
+
   "@img/sharp-libvips-darwin-arm64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-darwin-arm64@1.3.0":
     optional: true
 
   "@img/sharp-libvips-darwin-x64@1.2.4":
     optional: true
 
+  "@img/sharp-libvips-darwin-x64@1.3.0":
+    optional: true
+
   "@img/sharp-libvips-linux-arm64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-arm64@1.3.0":
     optional: true
 
   "@img/sharp-libvips-linux-arm@1.2.4":
     optional: true
 
+  "@img/sharp-libvips-linux-arm@1.3.0":
+    optional: true
+
   "@img/sharp-libvips-linux-ppc64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-ppc64@1.3.0":
     optional: true
 
   "@img/sharp-libvips-linux-riscv64@1.2.4":
     optional: true
 
+  "@img/sharp-libvips-linux-riscv64@1.3.0":
+    optional: true
+
   "@img/sharp-libvips-linux-s390x@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-s390x@1.3.0":
     optional: true
 
   "@img/sharp-libvips-linux-x64@1.2.4":
     optional: true
 
+  "@img/sharp-libvips-linux-x64@1.3.0":
+    optional: true
+
   "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
     optional: true
 
+  "@img/sharp-libvips-linuxmusl-arm64@1.3.0":
+    optional: true
+
   "@img/sharp-libvips-linuxmusl-x64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linuxmusl-x64@1.3.0":
     optional: true
 
   "@img/sharp-linux-arm64@0.34.5":
@@ -5634,9 +5672,19 @@ snapshots:
       "@img/sharp-libvips-linux-arm64": 1.2.4
     optional: true
 
+  "@img/sharp-linux-arm64@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-arm64": 1.3.0
+    optional: true
+
   "@img/sharp-linux-arm@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-linux-arm": 1.2.4
+    optional: true
+
+  "@img/sharp-linux-arm@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-arm": 1.3.0
     optional: true
 
   "@img/sharp-linux-ppc64@0.34.5":
@@ -5644,9 +5692,19 @@ snapshots:
       "@img/sharp-libvips-linux-ppc64": 1.2.4
     optional: true
 
+  "@img/sharp-linux-ppc64@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-ppc64": 1.3.0
+    optional: true
+
   "@img/sharp-linux-riscv64@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-linux-riscv64": 1.2.4
+    optional: true
+
+  "@img/sharp-linux-riscv64@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-riscv64": 1.3.0
     optional: true
 
   "@img/sharp-linux-s390x@0.34.5":
@@ -5654,9 +5712,19 @@ snapshots:
       "@img/sharp-libvips-linux-s390x": 1.2.4
     optional: true
 
+  "@img/sharp-linux-s390x@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-s390x": 1.3.0
+    optional: true
+
   "@img/sharp-linux-x64@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-linux-x64": 1.2.4
+    optional: true
+
+  "@img/sharp-linux-x64@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-x64": 1.3.0
     optional: true
 
   "@img/sharp-linuxmusl-arm64@0.34.5":
@@ -5664,149 +5732,297 @@ snapshots:
       "@img/sharp-libvips-linuxmusl-arm64": 1.2.4
     optional: true
 
+  "@img/sharp-linuxmusl-arm64@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linuxmusl-arm64": 1.3.0
+    optional: true
+
   "@img/sharp-linuxmusl-x64@0.34.5":
     optionalDependencies:
       "@img/sharp-libvips-linuxmusl-x64": 1.2.4
     optional: true
 
+  "@img/sharp-linuxmusl-x64@0.35.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linuxmusl-x64": 1.3.0
+    optional: true
+
   "@img/sharp-wasm32@0.34.5":
     dependencies:
-      "@emnapi/runtime": 1.8.1
+      "@emnapi/runtime": 1.11.0
+    optional: true
+
+  "@img/sharp-wasm32@0.35.1":
+    dependencies:
+      "@emnapi/runtime": 1.11.0
+    optional: true
+
+  "@img/sharp-webcontainers-wasm32@0.35.1":
+    dependencies:
+      "@img/sharp-wasm32": 0.35.1
     optional: true
 
   "@img/sharp-win32-arm64@0.34.5":
     optional: true
 
+  "@img/sharp-win32-arm64@0.35.1":
+    optional: true
+
   "@img/sharp-win32-ia32@0.34.5":
+    optional: true
+
+  "@img/sharp-win32-ia32@0.35.1":
     optional: true
 
   "@img/sharp-win32-x64@0.34.5":
     optional: true
 
+  "@img/sharp-win32-x64@0.35.1":
+    optional: true
+
   "@inquirer/ansi@1.0.2": {}
 
-  "@inquirer/checkbox@4.3.2(@types/node@25.0.10)":
+  "@inquirer/ansi@2.0.7": {}
+
+  "@inquirer/checkbox@4.3.2(@types/node@25.9.3)":
     dependencies:
       "@inquirer/ansi": 1.0.2
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
       "@inquirer/figures": 1.0.15
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/confirm@5.1.21(@types/node@25.0.10)":
+  "@inquirer/checkbox@5.2.1(@types/node@25.9.3)":
     dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
+      "@inquirer/ansi": 2.0.7
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/figures": 2.0.7
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/core@10.3.2(@types/node@25.0.10)":
+  "@inquirer/confirm@5.1.21(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/confirm@6.1.1(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/core@10.3.2(@types/node@25.9.3)":
     dependencies:
       "@inquirer/ansi": 1.0.2
       "@inquirer/figures": 1.0.15
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/editor@4.2.23(@types/node@25.0.10)":
+  "@inquirer/core@11.2.1(@types/node@25.9.3)":
     dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/external-editor": 1.0.3(@types/node@25.0.10)
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
+      "@inquirer/ansi": 2.0.7
+      "@inquirer/figures": 2.0.7
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/expand@4.0.23(@types/node@25.0.10)":
+  "@inquirer/editor@4.2.23(@types/node@25.9.3)":
     dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/external-editor": 1.0.3(@types/node@25.9.3)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/editor@5.2.2(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/external-editor": 3.0.3(@types/node@25.9.3)
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/expand@4.0.23(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/external-editor@1.0.3(@types/node@25.0.10)":
+  "@inquirer/expand@5.1.1(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/external-editor@1.0.3(@types/node@25.9.3)":
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
+
+  "@inquirer/external-editor@3.0.3(@types/node@25.9.3)":
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      "@types/node": 25.9.3
 
   "@inquirer/figures@1.0.15": {}
 
-  "@inquirer/input@4.3.1(@types/node@25.0.10)":
-    dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
-    optionalDependencies:
-      "@types/node": 25.0.10
+  "@inquirer/figures@2.0.7": {}
 
-  "@inquirer/number@3.0.23(@types/node@25.0.10)":
+  "@inquirer/input@4.3.1(@types/node@25.9.3)":
     dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/password@4.0.23(@types/node@25.0.10)":
+  "@inquirer/input@5.1.2(@types/node@25.9.3)":
     dependencies:
-      "@inquirer/ansi": 1.0.2
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/prompts@7.10.1(@types/node@25.0.10)":
+  "@inquirer/number@3.0.23(@types/node@25.9.3)":
     dependencies:
-      "@inquirer/checkbox": 4.3.2(@types/node@25.0.10)
-      "@inquirer/confirm": 5.1.21(@types/node@25.0.10)
-      "@inquirer/editor": 4.2.23(@types/node@25.0.10)
-      "@inquirer/expand": 4.0.23(@types/node@25.0.10)
-      "@inquirer/input": 4.3.1(@types/node@25.0.10)
-      "@inquirer/number": 3.0.23(@types/node@25.0.10)
-      "@inquirer/password": 4.0.23(@types/node@25.0.10)
-      "@inquirer/rawlist": 4.1.11(@types/node@25.0.10)
-      "@inquirer/search": 3.2.2(@types/node@25.0.10)
-      "@inquirer/select": 4.4.2(@types/node@25.0.10)
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/rawlist@4.1.11(@types/node@25.0.10)":
+  "@inquirer/number@4.1.1(@types/node@25.9.3)":
     dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
-      yoctocolors-cjs: 2.1.3
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/search@3.2.2(@types/node@25.0.10)":
-    dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/figures": 1.0.15
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      "@types/node": 25.0.10
-
-  "@inquirer/select@4.4.2(@types/node@25.0.10)":
+  "@inquirer/password@4.0.23(@types/node@25.9.3)":
     dependencies:
       "@inquirer/ansi": 1.0.2
-      "@inquirer/core": 10.3.2(@types/node@25.0.10)
-      "@inquirer/figures": 1.0.15
-      "@inquirer/type": 3.0.10(@types/node@25.0.10)
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/password@5.1.1(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/ansi": 2.0.7
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/prompts@7.10.1(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/checkbox": 4.3.2(@types/node@25.9.3)
+      "@inquirer/confirm": 5.1.21(@types/node@25.9.3)
+      "@inquirer/editor": 4.2.23(@types/node@25.9.3)
+      "@inquirer/expand": 4.0.23(@types/node@25.9.3)
+      "@inquirer/input": 4.3.1(@types/node@25.9.3)
+      "@inquirer/number": 3.0.23(@types/node@25.9.3)
+      "@inquirer/password": 4.0.23(@types/node@25.9.3)
+      "@inquirer/rawlist": 4.1.11(@types/node@25.9.3)
+      "@inquirer/search": 3.2.2(@types/node@25.9.3)
+      "@inquirer/select": 4.4.2(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/prompts@8.5.2(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/checkbox": 5.2.1(@types/node@25.9.3)
+      "@inquirer/confirm": 6.1.1(@types/node@25.9.3)
+      "@inquirer/editor": 5.2.2(@types/node@25.9.3)
+      "@inquirer/expand": 5.1.1(@types/node@25.9.3)
+      "@inquirer/input": 5.1.2(@types/node@25.9.3)
+      "@inquirer/number": 4.1.1(@types/node@25.9.3)
+      "@inquirer/password": 5.1.1(@types/node@25.9.3)
+      "@inquirer/rawlist": 5.3.1(@types/node@25.9.3)
+      "@inquirer/search": 4.2.1(@types/node@25.9.3)
+      "@inquirer/select": 5.2.1(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/rawlist@4.1.11(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
-  "@inquirer/type@3.0.10(@types/node@25.0.10)":
+  "@inquirer/rawlist@5.3.1(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
+
+  "@inquirer/search@3.2.2(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/figures": 1.0.15
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/search@4.2.1(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/figures": 2.0.7
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/select@4.4.2(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/ansi": 1.0.2
+      "@inquirer/core": 10.3.2(@types/node@25.9.3)
+      "@inquirer/figures": 1.0.15
+      "@inquirer/type": 3.0.10(@types/node@25.9.3)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/select@5.2.1(@types/node@25.9.3)":
+    dependencies:
+      "@inquirer/ansi": 2.0.7
+      "@inquirer/core": 11.2.1(@types/node@25.9.3)
+      "@inquirer/figures": 2.0.7
+      "@inquirer/type": 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/type@3.0.10(@types/node@25.9.3)":
+    optionalDependencies:
+      "@types/node": 25.9.3
+
+  "@inquirer/type@4.0.7(@types/node@25.9.3)":
+    optionalDependencies:
+      "@types/node": 25.9.3
 
   "@jridgewell/gen-mapping@0.3.13":
     dependencies:
@@ -5822,18 +6038,18 @@ snapshots:
       "@jridgewell/resolve-uri": 3.1.2
       "@jridgewell/sourcemap-codec": 1.5.5
 
-  "@lnai/core@0.6.5":
+  "@lnai/core@0.6.91":
     dependencies:
       gray-matter: 4.0.3
-      zod: 4.3.6
+      zod: 4.4.3
 
   "@mdx-js/mdx@3.1.1":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.4
-      "@types/mdx": 2.0.13
-      acorn: 8.15.0
+      "@types/mdx": 2.0.14
+      acorn: 8.17.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -5842,7 +6058,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.15.0)
+      recma-jsx: 1.0.1(acorn@8.17.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -5859,136 +6075,146 @@ snapshots:
 
   "@oslojs/encoding@1.1.0": {}
 
-  "@pagefind/darwin-arm64@1.4.0":
+  "@pagefind/darwin-arm64@1.5.2":
     optional: true
 
-  "@pagefind/darwin-x64@1.4.0":
+  "@pagefind/darwin-x64@1.5.2":
     optional: true
 
-  "@pagefind/default-ui@1.4.0": {}
+  "@pagefind/default-ui@1.5.2": {}
 
-  "@pagefind/freebsd-x64@1.4.0":
+  "@pagefind/freebsd-x64@1.5.2":
     optional: true
 
-  "@pagefind/linux-arm64@1.4.0":
+  "@pagefind/linux-arm64@1.5.2":
     optional: true
 
-  "@pagefind/linux-x64@1.4.0":
+  "@pagefind/linux-x64@1.5.2":
     optional: true
 
-  "@pagefind/windows-x64@1.4.0":
+  "@pagefind/windows-arm64@1.5.2":
     optional: true
 
-  "@rollup/pluginutils@5.3.0(rollup@4.56.0)":
+  "@pagefind/windows-x64@1.5.2":
+    optional: true
+
+  "@rollup/pluginutils@5.4.0(rollup@4.61.1)":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.56.0
+      rollup: 4.61.1
 
-  "@rollup/rollup-android-arm-eabi@4.56.0":
+  "@rollup/rollup-android-arm-eabi@4.61.1":
     optional: true
 
-  "@rollup/rollup-android-arm64@4.56.0":
+  "@rollup/rollup-android-arm64@4.61.1":
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.56.0":
+  "@rollup/rollup-darwin-arm64@4.61.1":
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.56.0":
+  "@rollup/rollup-darwin-x64@4.61.1":
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.56.0":
+  "@rollup/rollup-freebsd-arm64@4.61.1":
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.56.0":
+  "@rollup/rollup-freebsd-x64@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.56.0":
+  "@rollup/rollup-linux-arm-gnueabihf@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.56.0":
+  "@rollup/rollup-linux-arm-musleabihf@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.56.0":
+  "@rollup/rollup-linux-arm64-gnu@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.56.0":
+  "@rollup/rollup-linux-arm64-musl@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-loong64-gnu@4.56.0":
+  "@rollup/rollup-linux-loong64-gnu@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-loong64-musl@4.56.0":
+  "@rollup/rollup-linux-loong64-musl@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.56.0":
+  "@rollup/rollup-linux-ppc64-gnu@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-ppc64-musl@4.56.0":
+  "@rollup/rollup-linux-ppc64-musl@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.56.0":
+  "@rollup/rollup-linux-riscv64-gnu@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.56.0":
+  "@rollup/rollup-linux-riscv64-musl@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.56.0":
+  "@rollup/rollup-linux-s390x-gnu@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.56.0":
+  "@rollup/rollup-linux-x64-gnu@4.61.1":
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.56.0":
+  "@rollup/rollup-linux-x64-musl@4.61.1":
     optional: true
 
-  "@rollup/rollup-openbsd-x64@4.56.0":
+  "@rollup/rollup-openbsd-x64@4.61.1":
     optional: true
 
-  "@rollup/rollup-openharmony-arm64@4.56.0":
+  "@rollup/rollup-openharmony-arm64@4.61.1":
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.56.0":
+  "@rollup/rollup-win32-arm64-msvc@4.61.1":
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.56.0":
+  "@rollup/rollup-win32-ia32-msvc@4.61.1":
     optional: true
 
-  "@rollup/rollup-win32-x64-gnu@4.56.0":
+  "@rollup/rollup-win32-x64-gnu@4.61.1":
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.56.0":
+  "@rollup/rollup-win32-x64-msvc@4.61.1":
     optional: true
 
-  "@shikijs/core@3.21.0":
+  "@shikijs/core@4.2.0":
     dependencies:
-      "@shikijs/types": 3.21.0
+      "@shikijs/primitive": 4.2.0
+      "@shikijs/types": 4.2.0
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
       hast-util-to-html: 9.0.5
 
-  "@shikijs/engine-javascript@3.21.0":
+  "@shikijs/engine-javascript@4.2.0":
     dependencies:
-      "@shikijs/types": 3.21.0
+      "@shikijs/types": 4.2.0
       "@shikijs/vscode-textmate": 10.0.2
-      oniguruma-to-es: 4.3.4
+      oniguruma-to-es: 4.3.6
 
-  "@shikijs/engine-oniguruma@3.21.0":
+  "@shikijs/engine-oniguruma@4.2.0":
     dependencies:
-      "@shikijs/types": 3.21.0
+      "@shikijs/types": 4.2.0
       "@shikijs/vscode-textmate": 10.0.2
 
-  "@shikijs/langs@3.21.0":
+  "@shikijs/langs@4.2.0":
     dependencies:
-      "@shikijs/types": 3.21.0
+      "@shikijs/types": 4.2.0
 
-  "@shikijs/themes@3.21.0":
+  "@shikijs/primitive@4.2.0":
     dependencies:
-      "@shikijs/types": 3.21.0
+      "@shikijs/types": 4.2.0
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
 
-  "@shikijs/types@3.21.0":
+  "@shikijs/themes@4.2.0":
+    dependencies:
+      "@shikijs/types": 4.2.0
+
+  "@shikijs/types@4.2.0":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
@@ -5997,22 +6223,42 @@ snapshots:
 
   "@standard-schema/spec@1.1.0": {}
 
+  "@turbo/darwin-64@2.9.18":
+    optional: true
+
+  "@turbo/darwin-arm64@2.9.18":
+    optional: true
+
+  "@turbo/linux-64@2.9.18":
+    optional: true
+
+  "@turbo/linux-arm64@2.9.18":
+    optional: true
+
+  "@turbo/windows-64@2.9.18":
+    optional: true
+
+  "@turbo/windows-arm64@2.9.18":
+    optional: true
+
   "@types/chai@5.2.3":
     dependencies:
       "@types/deep-eql": 4.0.2
       assertion-error: 2.0.1
 
-  "@types/debug@4.1.12":
+  "@types/debug@4.1.13":
     dependencies:
       "@types/ms": 2.1.0
 
   "@types/deep-eql@4.0.2": {}
 
+  "@types/esrecurse@4.3.1": {}
+
   "@types/estree-jsx@1.0.5":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
 
-  "@types/estree@1.0.8": {}
+  "@types/estree@1.0.9": {}
 
   "@types/hast@3.0.4":
     dependencies:
@@ -6026,7 +6272,7 @@ snapshots:
     dependencies:
       "@types/unist": 3.0.3
 
-  "@types/mdx@2.0.13": {}
+  "@types/mdx@2.0.14": {}
 
   "@types/ms@2.1.0": {}
 
@@ -6034,170 +6280,170 @@ snapshots:
     dependencies:
       "@types/unist": 3.0.3
 
-  "@types/node@17.0.45": {}
-
-  "@types/node@25.0.10":
+  "@types/node@24.13.2":
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 7.18.2
+
+  "@types/node@25.9.3":
+    dependencies:
+      undici-types: 7.24.6
 
   "@types/sax@1.2.7":
     dependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
 
   "@types/unist@2.0.11": {}
 
   "@types/unist@3.0.3": {}
 
-  "@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)":
+  "@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.53.1(eslint@9.39.2)(typescript@5.9.3)
-      "@typescript-eslint/scope-manager": 8.53.1
-      "@typescript-eslint/type-utils": 8.53.1(eslint@9.39.2)(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.53.1(eslint@9.39.2)(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.53.1
-      eslint: 9.39.2
+      "@typescript-eslint/parser": 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      "@typescript-eslint/scope-manager": 8.61.0
+      "@typescript-eslint/type-utils": 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      "@typescript-eslint/visitor-keys": 8.61.0
+      eslint: 10.4.1
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.53.1(eslint@9.39.2)(typescript@5.9.3)":
+  "@typescript-eslint/parser@8.61.0(eslint@10.4.1)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/scope-manager": 8.53.1
-      "@typescript-eslint/types": 8.53.1
-      "@typescript-eslint/typescript-estree": 8.53.1(typescript@5.9.3)
-      "@typescript-eslint/visitor-keys": 8.53.1
+      "@typescript-eslint/scope-manager": 8.61.0
+      "@typescript-eslint/types": 8.61.0
+      "@typescript-eslint/typescript-estree": 8.61.0(typescript@6.0.3)
+      "@typescript-eslint/visitor-keys": 8.61.0
       debug: 4.4.3
-      eslint: 9.39.2
-      typescript: 5.9.3
+      eslint: 10.4.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.53.1(typescript@5.9.3)":
+  "@typescript-eslint/project-service@8.61.0(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.53.1(typescript@5.9.3)
-      "@typescript-eslint/types": 8.53.1
+      "@typescript-eslint/tsconfig-utils": 8.61.0(typescript@6.0.3)
+      "@typescript-eslint/types": 8.61.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.53.1":
+  "@typescript-eslint/scope-manager@8.61.0":
     dependencies:
-      "@typescript-eslint/types": 8.53.1
-      "@typescript-eslint/visitor-keys": 8.53.1
+      "@typescript-eslint/types": 8.61.0
+      "@typescript-eslint/visitor-keys": 8.61.0
 
-  "@typescript-eslint/tsconfig-utils@8.53.1(typescript@5.9.3)":
+  "@typescript-eslint/tsconfig-utils@8.61.0(typescript@6.0.3)":
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  "@typescript-eslint/type-utils@8.53.1(eslint@9.39.2)(typescript@5.9.3)":
+  "@typescript-eslint/type-utils@8.61.0(eslint@10.4.1)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/types": 8.53.1
-      "@typescript-eslint/typescript-estree": 8.53.1(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.53.1(eslint@9.39.2)(typescript@5.9.3)
+      "@typescript-eslint/types": 8.61.0
+      "@typescript-eslint/typescript-estree": 8.61.0(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.61.0(eslint@10.4.1)(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 9.39.2
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      eslint: 10.4.1
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.53.1": {}
+  "@typescript-eslint/types@8.61.0": {}
 
-  "@typescript-eslint/typescript-estree@8.53.1(typescript@5.9.3)":
+  "@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/project-service": 8.53.1(typescript@5.9.3)
-      "@typescript-eslint/tsconfig-utils": 8.53.1(typescript@5.9.3)
-      "@typescript-eslint/types": 8.53.1
-      "@typescript-eslint/visitor-keys": 8.53.1
+      "@typescript-eslint/project-service": 8.61.0(typescript@6.0.3)
+      "@typescript-eslint/tsconfig-utils": 8.61.0(typescript@6.0.3)
+      "@typescript-eslint/types": 8.61.0
+      "@typescript-eslint/visitor-keys": 8.61.0
       debug: 4.4.3
-      minimatch: 9.0.5
-      semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      minimatch: 10.2.5
+      semver: 7.8.4
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.53.1(eslint@9.39.2)(typescript@5.9.3)":
+  "@typescript-eslint/utils@8.61.0(eslint@10.4.1)(typescript@6.0.3)":
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2)
-      "@typescript-eslint/scope-manager": 8.53.1
-      "@typescript-eslint/types": 8.53.1
-      "@typescript-eslint/typescript-estree": 8.53.1(typescript@5.9.3)
-      eslint: 9.39.2
-      typescript: 5.9.3
+      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.1)
+      "@typescript-eslint/scope-manager": 8.61.0
+      "@typescript-eslint/types": 8.61.0
+      "@typescript-eslint/typescript-estree": 8.61.0(typescript@6.0.3)
+      eslint: 10.4.1
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.53.1":
+  "@typescript-eslint/visitor-keys@8.61.0":
     dependencies:
-      "@typescript-eslint/types": 8.53.1
-      eslint-visitor-keys: 4.2.1
+      "@typescript-eslint/types": 8.61.0
+      eslint-visitor-keys: 5.0.1
 
-  "@ungap/structured-clone@1.3.0": {}
+  "@ungap/structured-clone@1.3.1": {}
 
-  "@vitest/expect@4.0.18":
+  "@vitest/expect@4.1.8":
     dependencies:
       "@standard-schema/spec": 1.1.0
       "@types/chai": 5.2.3
-      "@vitest/spy": 4.0.18
-      "@vitest/utils": 4.0.18
+      "@vitest/spy": 4.1.8
+      "@vitest/utils": 4.1.8
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.0.18(vite@6.4.1(@types/node@25.0.10)(yaml@2.8.2))":
+  "@vitest/mocker@4.1.8(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))":
     dependencies:
-      "@vitest/spy": 4.0.18
+      "@vitest/spy": 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.0.10)(yaml@2.8.2)
+      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
 
-  "@vitest/pretty-format@4.0.18":
+  "@vitest/pretty-format@4.1.8":
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  "@vitest/runner@4.0.18":
+  "@vitest/runner@4.1.8":
     dependencies:
-      "@vitest/utils": 4.0.18
+      "@vitest/utils": 4.1.8
       pathe: 2.0.3
 
-  "@vitest/snapshot@4.0.18":
+  "@vitest/snapshot@4.1.8":
     dependencies:
-      "@vitest/pretty-format": 4.0.18
+      "@vitest/pretty-format": 4.1.8
+      "@vitest/utils": 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@4.0.18": {}
+  "@vitest/spy@4.1.8": {}
 
-  "@vitest/utils@4.0.18":
+  "@vitest/utils@4.1.8":
     dependencies:
-      "@vitest/pretty-format": 4.0.18
-      tinyrainbow: 3.0.3
+      "@vitest/pretty-format": 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.17.0
 
-  acorn@8.15.0: {}
+  acorn@8.17.0: {}
 
-  ajv@6.12.6:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-align@3.0.1:
-    dependencies:
-      string-width: 4.2.3
-
-  ansi-escapes@7.2.0:
+  ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
 
@@ -6216,7 +6462,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   arg@5.0.2: {}
 
@@ -6234,76 +6480,68 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.6(astro@5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2)):
+  astro-expressive-code@0.43.1(astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)):
     dependencies:
-      astro: 5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2)
-      rehype-expressive-code: 0.41.6
+      astro: 6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0)
+      rehype-expressive-code: 0.43.1
 
-  astro@5.16.15(@types/node@25.0.10)(rollup@4.56.0)(typescript@5.9.3)(yaml@2.8.2):
+  astro@6.4.6(@types/node@25.9.3)(rollup@4.61.1)(yaml@2.9.0):
     dependencies:
-      "@astrojs/compiler": 2.13.0
-      "@astrojs/internal-helpers": 0.7.5
-      "@astrojs/markdown-remark": 6.3.10
-      "@astrojs/telemetry": 3.3.0
+      "@astrojs/compiler": 4.0.0
+      "@astrojs/internal-helpers": 0.10.0
+      "@astrojs/markdown-remark": 7.2.0
+      "@astrojs/telemetry": 3.3.2
       "@capsizecss/unpack": 4.0.0
+      "@clack/prompts": 1.5.1
       "@oslojs/encoding": 1.1.0
-      "@rollup/pluginutils": 5.3.0(rollup@4.56.0)
-      acorn: 8.15.0
+      "@rollup/pluginutils": 5.4.0(rollup@4.61.1)
       aria-query: 5.3.2
       axobject-query: 4.1.0
-      boxen: 8.0.1
-      ci-info: 4.3.1
+      ci-info: 4.4.0
       clsx: 2.1.1
-      common-ancestor-path: 1.0.1
+      common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      cssesc: 3.0.0
-      debug: 4.4.3
-      deterministic-object-hash: 2.0.2
-      devalue: 5.6.2
-      diff: 8.0.3
-      dlv: 1.1.3
+      devalue: 5.8.1
+      diff: 8.0.4
       dset: 3.1.4
-      es-module-lexer: 1.7.0
-      esbuild: 0.25.12
-      estree-walker: 3.0.3
+      es-module-lexer: 2.1.0
+      esbuild: 0.27.7
       flattie: 1.1.1
-      fontace: 0.4.0
+      fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      import-meta-resolve: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
+      jsonc-parser: 3.3.1
       magic-string: 0.30.21
-      magicast: 0.5.1
+      magicast: 0.5.3
       mrmime: 2.0.1
       neotraverse: 0.6.18
-      p-limit: 6.2.0
-      p-queue: 8.1.1
+      obug: 2.1.2
+      p-limit: 7.3.0
+      p-queue: 9.3.0
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
-      picomatch: 4.0.3
-      prompts: 2.4.2
+      picomatch: 4.0.4
       rehype: 13.0.2
-      semver: 7.7.3
-      shiki: 3.21.0
-      smol-toml: 1.6.0
-      svgo: 4.0.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.3)
+      semver: 7.8.4
+      shiki: 4.2.0
+      smol-toml: 1.6.1
+      svgo: 4.0.1
+      tinyclip: 0.1.14
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       ultrahtml: 1.6.0
-      unifont: 0.7.3
+      unifont: 0.7.4
       unist-util-visit: 5.1.0
-      unstorage: 1.17.4
+      unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@25.0.10)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@25.0.10)(yaml@2.8.2))
+      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
-      yargs-parser: 21.1.1
-      yocto-spinner: 0.2.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+      yargs-parser: 22.0.0
+      zod: 4.4.3
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -6337,7 +6575,6 @@ snapshots:
       - supports-color
       - terser
       - tsx
-      - typescript
       - uploadthing
       - yaml
 
@@ -6345,9 +6582,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
-  base-64@1.0.0: {}
+  balanced-match@4.0.4: {}
 
   bcp-47-match@2.0.3: {}
 
@@ -6359,49 +6594,20 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  boxen@8.0.1:
+  brace-expansion@5.0.6:
     dependencies:
-      ansi-align: 3.0.1
-      camelcase: 8.0.0
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      string-width: 7.2.0
-      type-fest: 4.41.0
-      widest-line: 5.0.0
-      wrap-ansi: 9.0.2
+      balanced-match: 4.0.4
 
-  brace-expansion@1.1.12:
+  bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
-
-  bundle-require@5.1.0(esbuild@0.27.2):
-    dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
 
-  callsites@3.1.0: {}
-
-  camelcase@8.0.0: {}
-
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
-
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
 
   chalk@5.6.2: {}
 
@@ -6423,9 +6629,7 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  ci-info@4.3.1: {}
-
-  cli-boxes@3.0.0: {}
+  ci-info@4.4.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -6433,10 +6637,10 @@ snapshots:
 
   cli-spinners@3.4.0: {}
 
-  cli-truncate@5.1.1:
+  cli-truncate@5.2.0:
     dependencies:
-      slice-ansi: 7.1.2
-      string-width: 8.1.0
+      slice-ansi: 8.0.0
+      string-width: 8.2.1
 
   cli-width@4.1.0: {}
 
@@ -6450,25 +6654,25 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colorette@2.0.20: {}
-
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
 
-  commander@14.0.2: {}
+  commander@14.0.3: {}
+
+  commander@15.0.0: {}
 
   commander@4.1.1: {}
 
-  common-ancestor-path@1.0.1: {}
-
-  concat-map@0.0.1: {}
+  common-ancestor-path@2.0.0: {}
 
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
 
-  cookie-es@1.2.2: {}
+  convert-source-map@2.0.0: {}
+
+  cookie-es@1.2.3: {}
 
   cookie@1.1.1: {}
 
@@ -6497,9 +6701,9 @@ snapshots:
       mdn-data: 2.0.28
       source-map-js: 1.2.1
 
-  css-tree@3.1.0:
+  css-tree@3.2.1:
     dependencies:
-      mdn-data: 2.12.2
+      mdn-data: 2.27.1
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
@@ -6520,7 +6724,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   dequal@2.0.3: {}
 
@@ -6528,21 +6732,15 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  deterministic-object-hash@2.0.2:
-    dependencies:
-      base-64: 1.0.0
-
-  devalue@5.6.2: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
 
-  diff@8.0.3: {}
+  diff@8.0.4: {}
 
   direction@2.0.1: {}
-
-  dlv@1.1.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -6574,7 +6772,7 @@ snapshots:
 
   environment@1.1.0: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -6586,107 +6784,77 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       "@types/estree-jsx": 1.0.5
-      acorn: 8.15.0
+      acorn: 8.17.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  esbuild@0.25.12:
+  esbuild@0.27.7:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.12
-      "@esbuild/android-arm": 0.25.12
-      "@esbuild/android-arm64": 0.25.12
-      "@esbuild/android-x64": 0.25.12
-      "@esbuild/darwin-arm64": 0.25.12
-      "@esbuild/darwin-x64": 0.25.12
-      "@esbuild/freebsd-arm64": 0.25.12
-      "@esbuild/freebsd-x64": 0.25.12
-      "@esbuild/linux-arm": 0.25.12
-      "@esbuild/linux-arm64": 0.25.12
-      "@esbuild/linux-ia32": 0.25.12
-      "@esbuild/linux-loong64": 0.25.12
-      "@esbuild/linux-mips64el": 0.25.12
-      "@esbuild/linux-ppc64": 0.25.12
-      "@esbuild/linux-riscv64": 0.25.12
-      "@esbuild/linux-s390x": 0.25.12
-      "@esbuild/linux-x64": 0.25.12
-      "@esbuild/netbsd-arm64": 0.25.12
-      "@esbuild/netbsd-x64": 0.25.12
-      "@esbuild/openbsd-arm64": 0.25.12
-      "@esbuild/openbsd-x64": 0.25.12
-      "@esbuild/openharmony-arm64": 0.25.12
-      "@esbuild/sunos-x64": 0.25.12
-      "@esbuild/win32-arm64": 0.25.12
-      "@esbuild/win32-ia32": 0.25.12
-      "@esbuild/win32-x64": 0.25.12
-
-  esbuild@0.27.2:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.27.2
-      "@esbuild/android-arm": 0.27.2
-      "@esbuild/android-arm64": 0.27.2
-      "@esbuild/android-x64": 0.27.2
-      "@esbuild/darwin-arm64": 0.27.2
-      "@esbuild/darwin-x64": 0.27.2
-      "@esbuild/freebsd-arm64": 0.27.2
-      "@esbuild/freebsd-x64": 0.27.2
-      "@esbuild/linux-arm": 0.27.2
-      "@esbuild/linux-arm64": 0.27.2
-      "@esbuild/linux-ia32": 0.27.2
-      "@esbuild/linux-loong64": 0.27.2
-      "@esbuild/linux-mips64el": 0.27.2
-      "@esbuild/linux-ppc64": 0.27.2
-      "@esbuild/linux-riscv64": 0.27.2
-      "@esbuild/linux-s390x": 0.27.2
-      "@esbuild/linux-x64": 0.27.2
-      "@esbuild/netbsd-arm64": 0.27.2
-      "@esbuild/netbsd-x64": 0.27.2
-      "@esbuild/openbsd-arm64": 0.27.2
-      "@esbuild/openbsd-x64": 0.27.2
-      "@esbuild/openharmony-arm64": 0.27.2
-      "@esbuild/sunos-x64": 0.27.2
-      "@esbuild/win32-arm64": 0.27.2
-      "@esbuild/win32-ia32": 0.27.2
-      "@esbuild/win32-x64": 0.27.2
+      "@esbuild/aix-ppc64": 0.27.7
+      "@esbuild/android-arm": 0.27.7
+      "@esbuild/android-arm64": 0.27.7
+      "@esbuild/android-x64": 0.27.7
+      "@esbuild/darwin-arm64": 0.27.7
+      "@esbuild/darwin-x64": 0.27.7
+      "@esbuild/freebsd-arm64": 0.27.7
+      "@esbuild/freebsd-x64": 0.27.7
+      "@esbuild/linux-arm": 0.27.7
+      "@esbuild/linux-arm64": 0.27.7
+      "@esbuild/linux-ia32": 0.27.7
+      "@esbuild/linux-loong64": 0.27.7
+      "@esbuild/linux-mips64el": 0.27.7
+      "@esbuild/linux-ppc64": 0.27.7
+      "@esbuild/linux-riscv64": 0.27.7
+      "@esbuild/linux-s390x": 0.27.7
+      "@esbuild/linux-x64": 0.27.7
+      "@esbuild/netbsd-arm64": 0.27.7
+      "@esbuild/netbsd-x64": 0.27.7
+      "@esbuild/openbsd-arm64": 0.27.7
+      "@esbuild/openbsd-x64": 0.27.7
+      "@esbuild/openharmony-arm64": 0.27.7
+      "@esbuild/sunos-x64": 0.27.7
+      "@esbuild/win32-arm64": 0.27.7
+      "@esbuild/win32-ia32": 0.27.7
+      "@esbuild/win32-x64": 0.27.7
 
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2):
+  eslint-plugin-simple-import-sort@13.0.0(eslint@10.4.1):
     dependencies:
-      eslint: 9.39.2
+      eslint: 10.4.1
 
-  eslint-scope@8.4.0:
+  eslint-scope@9.1.2:
     dependencies:
+      "@types/esrecurse": 4.3.1
+      "@types/estree": 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.2.1: {}
+  eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.2:
+  eslint@10.4.1:
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.2)
+      "@eslint-community/eslint-utils": 4.9.1(eslint@10.4.1)
       "@eslint-community/regexpp": 4.12.2
-      "@eslint/config-array": 0.21.1
-      "@eslint/config-helpers": 0.4.2
-      "@eslint/core": 0.17.0
-      "@eslint/eslintrc": 3.3.3
-      "@eslint/js": 9.39.2
-      "@eslint/plugin-kit": 0.4.1
-      "@humanfs/node": 0.16.7
+      "@eslint/config-array": 0.23.5
+      "@eslint/config-helpers": 0.6.0
+      "@eslint/core": 1.2.1
+      "@eslint/plugin-kit": 0.7.2
+      "@humanfs/node": 0.16.8
       "@humanwhocodes/module-importer": 1.0.1
       "@humanwhocodes/retry": 0.4.3
-      "@types/estree": 1.0.8
-      ajv: 6.12.6
-      chalk: 4.1.2
+      "@types/estree": 1.0.9
+      ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -6697,18 +6865,17 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
       - supports-color
 
-  espree@10.4.0:
+  espree@11.2.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 4.2.1
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
 
@@ -6724,7 +6891,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -6737,7 +6904,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -6755,7 +6922,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
 
   esutils@2.0.3: {}
 
@@ -6763,12 +6930,12 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  expressive-code@0.41.6:
+  expressive-code@0.43.1:
     dependencies:
-      "@expressive-code/core": 0.41.6
-      "@expressive-code/plugin-frames": 0.41.6
-      "@expressive-code/plugin-shiki": 0.41.6
-      "@expressive-code/plugin-text-markers": 0.41.6
+      "@expressive-code/core": 0.43.1
+      "@expressive-code/plugin-frames": 0.43.1
+      "@expressive-code/plugin-shiki": 0.43.1
+      "@expressive-code/plugin-text-markers": 0.43.1
 
   extend-shallow@2.0.1:
     dependencies:
@@ -6782,17 +6949,23 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
 
   find-up@5.0.0:
     dependencies:
@@ -6802,30 +6975,34 @@ snapshots:
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
-      mlly: 1.8.0
-      rollup: 4.56.0
+      mlly: 1.8.2
+      rollup: 4.61.1
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   flattie@1.1.1: {}
 
-  fontace@0.4.0:
+  fontace@0.4.1:
     dependencies:
-      fontkitten: 1.0.2
+      fontkitten: 1.0.3
 
-  fontkitten@1.0.2:
+  fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
 
   fsevents@2.3.3:
     optional: true
 
-  get-east-asian-width@1.4.0: {}
+  get-east-asian-width@1.6.0: {}
+
+  get-tsconfig@5.0.0-beta.4:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
 
@@ -6833,9 +7010,7 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  globals@14.0.0: {}
-
-  globals@16.5.0: {}
+  globals@17.6.0: {}
 
   gray-matter@4.0.3:
     dependencies:
@@ -6844,19 +7019,17 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  h3@1.15.5:
+  h3@1.15.11:
     dependencies:
-      cookie-es: 1.2.2
+      cookie-es: 1.2.3
       crossws: 0.3.5
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.4
       radix3: 1.1.2
-      ufo: 1.6.3
+      ufo: 1.6.4
       uncrypto: 0.1.3
-
-  has-flag@4.0.0: {}
 
   hast-util-embedded@3.0.0:
     dependencies:
@@ -6888,7 +7061,7 @@ snapshots:
       "@types/unist": 3.0.3
       devlop: 1.1.0
       hastscript: 9.0.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       vfile: 6.0.3
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
@@ -6929,7 +7102,7 @@ snapshots:
     dependencies:
       "@types/hast": 3.0.4
       "@types/unist": 3.0.3
-      "@ungap/structured-clone": 1.3.0
+      "@ungap/structured-clone": 1.3.1
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.1
       html-void-elements: 3.0.0
@@ -6954,14 +7127,14 @@ snapshots:
       hast-util-to-string: 3.0.1
       hast-util-whitespace: 3.0.0
       nth-check: 2.1.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.4
       comma-separated-tokens: 2.0.3
@@ -6972,7 +7145,7 @@ snapshots:
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
       unist-util-position: 5.0.0
@@ -6989,14 +7162,14 @@ snapshots:
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
       mdast-util-to-hast: 13.2.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/hast": 3.0.4
       "@types/unist": 3.0.3
       comma-separated-tokens: 2.0.3
@@ -7006,7 +7179,7 @@ snapshots:
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
       unist-util-position: 5.0.0
@@ -7019,7 +7192,7 @@ snapshots:
       "@types/hast": 3.0.4
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -7044,7 +7217,7 @@ snapshots:
       "@types/hast": 3.0.4
       comma-separated-tokens: 2.0.3
       hast-util-parse-selector: 4.0.0
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
   html-escaper@3.0.3: {}
@@ -7057,9 +7230,9 @@ snapshots:
 
   husky@9.1.7: {}
 
-  i18next@23.16.8:
-    dependencies:
-      "@babel/runtime": 7.28.6
+  i18next@26.3.1(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   iconv-lite@0.7.2:
     dependencies:
@@ -7068,13 +7241,6 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
-
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
-  import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -7093,6 +7259,8 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-docker@4.0.0: {}
+
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
@@ -7101,7 +7269,7 @@ snapshots:
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.6.0
 
   is-glob@4.0.3:
     dependencies:
@@ -7115,13 +7283,11 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
-  is-number@7.0.0: {}
-
   is-plain-obj@4.1.0: {}
 
   is-unicode-supported@2.1.0: {}
 
-  is-wsl@3.1.0:
+  is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
@@ -7134,7 +7300,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -7144,13 +7310,13 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  jsonc-parser@3.3.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
   kind-of@6.0.3: {}
-
-  kleur@3.0.3: {}
 
   klona@2.0.6: {}
 
@@ -7163,32 +7329,30 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  lint-staged@16.2.7:
+  lint-staged@17.0.7:
     dependencies:
-      commander: 14.0.2
-      listr2: 9.0.5
-      micromatch: 4.0.8
-      nano-spawn: 2.0.0
-      pidtree: 0.6.0
+      listr2: 10.2.1
+      picomatch: 4.0.4
       string-argv: 0.3.2
-      yaml: 2.8.2
+      tinyexec: 1.2.4
+    optionalDependencies:
+      yaml: 2.9.0
 
-  listr2@9.0.5:
+  listr2@10.2.1:
     dependencies:
-      cli-truncate: 5.1.1
-      colorette: 2.0.20
+      cli-truncate: 5.2.0
       eventemitter3: 5.0.4
       log-update: 6.1.0
       rfdc: 1.4.1
-      wrap-ansi: 9.0.2
+      wrap-ansi: 10.0.0
 
-  lnai@0.6.5(@types/node@25.0.10):
+  lnai@0.6.91(@types/node@25.9.3):
     dependencies:
-      "@inquirer/prompts": 7.10.1(@types/node@25.0.10)
-      "@lnai/core": 0.6.5
+      "@inquirer/prompts": 7.10.1(@types/node@25.9.3)
+      "@lnai/core": 0.6.91
       chalk: 5.6.2
-      commander: 14.0.2
-      ora: 9.1.0
+      commander: 14.0.3
+      ora: 9.4.0
     transitivePeerDependencies:
       - "@types/node"
 
@@ -7198,8 +7362,6 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash.merge@4.6.2: {}
-
   log-symbols@7.0.1:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -7207,24 +7369,24 @@ snapshots:
 
   log-update@6.1.0:
     dependencies:
-      ansi-escapes: 7.2.0
+      ansi-escapes: 7.3.0
       cli-cursor: 5.0.0
       slice-ansi: 7.1.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
   longest-streak@3.1.0: {}
 
-  lru-cache@11.2.4: {}
+  lru-cache@11.5.1: {}
 
   magic-string@0.30.21:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
 
-  magicast@0.5.1:
+  magicast@0.5.3:
     dependencies:
-      "@babel/parser": 7.28.6
-      "@babel/types": 7.28.6
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
       source-map-js: 1.2.1
 
   markdown-extensions@2.0.0: {}
@@ -7243,7 +7405,7 @@ snapshots:
       "@types/unist": 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -7258,7 +7420,7 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.2:
+  mdast-util-from-markdown@2.0.3:
     dependencies:
       "@types/mdast": 4.0.4
       "@types/unist": 3.0.3
@@ -7287,7 +7449,7 @@ snapshots:
     dependencies:
       "@types/mdast": 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -7296,7 +7458,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       "@types/mdast": 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7306,7 +7468,7 @@ snapshots:
       "@types/mdast": 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7315,14 +7477,14 @@ snapshots:
     dependencies:
       "@types/mdast": 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -7338,7 +7500,7 @@ snapshots:
       "@types/hast": 3.0.4
       "@types/mdast": 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7351,7 +7513,7 @@ snapshots:
       "@types/unist": 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -7362,7 +7524,7 @@ snapshots:
 
   mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
@@ -7376,7 +7538,7 @@ snapshots:
       "@types/hast": 3.0.4
       "@types/mdast": 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7390,7 +7552,7 @@ snapshots:
     dependencies:
       "@types/hast": 3.0.4
       "@types/mdast": 4.0.4
-      "@ungap/structured-clone": 1.3.0
+      "@ungap/structured-clone": 1.3.1
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -7416,7 +7578,7 @@ snapshots:
 
   mdn-data@2.0.28: {}
 
-  mdn-data@2.12.2: {}
+  mdn-data@2.27.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -7437,7 +7599,7 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
-  micromark-extension-directive@3.0.2:
+  micromark-extension-directive@4.0.0:
     dependencies:
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
@@ -7507,7 +7669,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -7518,7 +7680,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -7535,7 +7697,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -7547,8 +7709,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -7571,7 +7733,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -7635,7 +7797,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/unist": 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -7672,7 +7834,7 @@ snapshots:
 
   micromark@4.0.2:
     dependencies:
-      "@types/debug": 4.1.12
+      "@types/debug": 4.1.13
       debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
@@ -7692,27 +7854,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.1
-
   mimic-function@5.0.1: {}
 
-  minimatch@3.1.2:
+  minimatch@10.2.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 5.0.6
 
-  minimatch@9.0.5:
+  mlly@1.8.2:
     dependencies:
-      brace-expansion: 2.0.2
-
-  mlly@1.8.0:
-    dependencies:
-      acorn: 8.15.0
+      acorn: 8.17.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   mrmime@2.0.1: {}
 
@@ -7720,15 +7873,15 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
+  mute-stream@3.0.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nano-spawn@2.0.0: {}
-
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -7750,13 +7903,13 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  obug@2.1.1: {}
+  obug@2.1.2: {}
 
   ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
       node-fetch-native: 1.6.7
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ohash@2.0.11: {}
 
@@ -7764,11 +7917,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-parser@0.12.1: {}
+  oniguruma-parser@0.12.2: {}
 
-  oniguruma-to-es@4.3.4:
+  oniguruma-to-es@4.3.6:
     dependencies:
-      oniguruma-parser: 0.12.1
+      oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
 
@@ -7781,7 +7934,7 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ora@9.1.0:
+  ora@9.4.0:
     dependencies:
       chalk: 5.6.2
       cli-cursor: 5.0.0
@@ -7789,14 +7942,14 @@ snapshots:
       is-interactive: 2.0.0
       is-unicode-supported: 2.1.0
       log-symbols: 7.0.1
-      stdin-discarder: 0.2.2
-      string-width: 8.1.0
+      stdin-discarder: 0.3.2
+      string-width: 8.2.1
 
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     dependencies:
       yocto-queue: 1.2.2
 
@@ -7804,27 +7957,24 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  p-queue@8.1.1:
+  p-queue@9.3.0:
     dependencies:
       eventemitter3: 5.0.4
-      p-timeout: 6.1.4
+      p-timeout: 7.0.1
 
-  p-timeout@6.1.4: {}
+  p-timeout@7.0.1: {}
 
   package-manager-detector@1.6.0: {}
 
-  pagefind@1.4.0:
+  pagefind@1.5.2:
     optionalDependencies:
-      "@pagefind/darwin-arm64": 1.4.0
-      "@pagefind/darwin-x64": 1.4.0
-      "@pagefind/freebsd-x64": 1.4.0
-      "@pagefind/linux-arm64": 1.4.0
-      "@pagefind/linux-x64": 1.4.0
-      "@pagefind/windows-x64": 1.4.0
-
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
+      "@pagefind/darwin-arm64": 1.5.2
+      "@pagefind/darwin-x64": 1.5.2
+      "@pagefind/freebsd-x64": 1.5.2
+      "@pagefind/linux-arm64": 1.5.2
+      "@pagefind/linux-x64": 1.5.2
+      "@pagefind/windows-arm64": 1.5.2
+      "@pagefind/windows-x64": 1.5.2
 
   parse-entities@4.0.2:
     dependencies:
@@ -7859,55 +8009,48 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
-
-  pidtree@0.6.0: {}
+  picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
 
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.0
+      mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.2):
+  postcss-load-config@6.0.1(postcss@8.5.15)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.6
-      yaml: 2.8.2
+      postcss: 8.5.15
+      yaml: 2.9.0
 
-  postcss-nested@6.2.0(postcss@8.5.6):
+  postcss-nested@6.2.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 6.1.2
+      postcss: 8.5.15
+      postcss-selector-parser: 6.1.4
 
-  postcss-selector-parser@6.1.2:
+  postcss-selector-parser@6.1.4:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.6:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.1: {}
+  prettier@3.8.4: {}
 
   prismjs@1.30.0: {}
 
-  prompts@2.4.2:
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
-
-  property-information@7.1.0: {}
+  property-information@7.2.0: {}
 
   punycode@2.3.1: {}
 
@@ -7919,14 +8062,14 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.15.0):
+  recma-jsx@1.0.1(acorn@8.17.0):
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -7934,14 +8077,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -7956,9 +8099,9 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  rehype-expressive-code@0.41.6:
+  rehype-expressive-code@0.43.1:
     dependencies:
-      expressive-code: 0.41.6
+      expressive-code: 0.43.1
 
   rehype-format@5.0.1:
     dependencies:
@@ -7979,7 +8122,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/hast": 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -7998,11 +8141,11 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
-  remark-directive@3.0.1:
+  remark-directive@4.0.0:
     dependencies:
       "@types/mdast": 4.0.4
       mdast-util-directive: 3.1.0
-      micromark-extension-directive: 3.0.2
+      micromark-extension-directive: 4.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -8028,7 +8171,7 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       "@types/mdast": 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -8055,9 +8198,9 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  resolve-from@4.0.0: {}
-
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
     dependencies:
@@ -8091,53 +8234,53 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup@4.56.0:
+  rollup@4.61.1:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.56.0
-      "@rollup/rollup-android-arm64": 4.56.0
-      "@rollup/rollup-darwin-arm64": 4.56.0
-      "@rollup/rollup-darwin-x64": 4.56.0
-      "@rollup/rollup-freebsd-arm64": 4.56.0
-      "@rollup/rollup-freebsd-x64": 4.56.0
-      "@rollup/rollup-linux-arm-gnueabihf": 4.56.0
-      "@rollup/rollup-linux-arm-musleabihf": 4.56.0
-      "@rollup/rollup-linux-arm64-gnu": 4.56.0
-      "@rollup/rollup-linux-arm64-musl": 4.56.0
-      "@rollup/rollup-linux-loong64-gnu": 4.56.0
-      "@rollup/rollup-linux-loong64-musl": 4.56.0
-      "@rollup/rollup-linux-ppc64-gnu": 4.56.0
-      "@rollup/rollup-linux-ppc64-musl": 4.56.0
-      "@rollup/rollup-linux-riscv64-gnu": 4.56.0
-      "@rollup/rollup-linux-riscv64-musl": 4.56.0
-      "@rollup/rollup-linux-s390x-gnu": 4.56.0
-      "@rollup/rollup-linux-x64-gnu": 4.56.0
-      "@rollup/rollup-linux-x64-musl": 4.56.0
-      "@rollup/rollup-openbsd-x64": 4.56.0
-      "@rollup/rollup-openharmony-arm64": 4.56.0
-      "@rollup/rollup-win32-arm64-msvc": 4.56.0
-      "@rollup/rollup-win32-ia32-msvc": 4.56.0
-      "@rollup/rollup-win32-x64-gnu": 4.56.0
-      "@rollup/rollup-win32-x64-msvc": 4.56.0
+      "@rollup/rollup-android-arm-eabi": 4.61.1
+      "@rollup/rollup-android-arm64": 4.61.1
+      "@rollup/rollup-darwin-arm64": 4.61.1
+      "@rollup/rollup-darwin-x64": 4.61.1
+      "@rollup/rollup-freebsd-arm64": 4.61.1
+      "@rollup/rollup-freebsd-x64": 4.61.1
+      "@rollup/rollup-linux-arm-gnueabihf": 4.61.1
+      "@rollup/rollup-linux-arm-musleabihf": 4.61.1
+      "@rollup/rollup-linux-arm64-gnu": 4.61.1
+      "@rollup/rollup-linux-arm64-musl": 4.61.1
+      "@rollup/rollup-linux-loong64-gnu": 4.61.1
+      "@rollup/rollup-linux-loong64-musl": 4.61.1
+      "@rollup/rollup-linux-ppc64-gnu": 4.61.1
+      "@rollup/rollup-linux-ppc64-musl": 4.61.1
+      "@rollup/rollup-linux-riscv64-gnu": 4.61.1
+      "@rollup/rollup-linux-riscv64-musl": 4.61.1
+      "@rollup/rollup-linux-s390x-gnu": 4.61.1
+      "@rollup/rollup-linux-x64-gnu": 4.61.1
+      "@rollup/rollup-linux-x64-musl": 4.61.1
+      "@rollup/rollup-openbsd-x64": 4.61.1
+      "@rollup/rollup-openharmony-arm64": 4.61.1
+      "@rollup/rollup-win32-arm64-msvc": 4.61.1
+      "@rollup/rollup-win32-ia32-msvc": 4.61.1
+      "@rollup/rollup-win32-x64-gnu": 4.61.1
+      "@rollup/rollup-win32-x64-msvc": 4.61.1
       fsevents: 2.3.3
 
   safer-buffer@2.1.2: {}
 
-  sax@1.4.4: {}
+  sax@1.6.0: {}
 
   section-matter@1.0.0:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  semver@7.7.3: {}
+  semver@7.8.4: {}
 
   sharp@0.34.5:
     dependencies:
-      "@img/colour": 1.0.0
+      "@img/colour": 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.4
     optionalDependencies:
       "@img/sharp-darwin-arm64": 0.34.5
       "@img/sharp-darwin-x64": 0.34.5
@@ -8163,6 +8306,39 @@ snapshots:
       "@img/sharp-win32-arm64": 0.34.5
       "@img/sharp-win32-ia32": 0.34.5
       "@img/sharp-win32-x64": 0.34.5
+    optional: true
+
+  sharp@0.35.1:
+    dependencies:
+      "@img/colour": 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.4
+    optionalDependencies:
+      "@img/sharp-darwin-arm64": 0.35.1
+      "@img/sharp-darwin-x64": 0.35.1
+      "@img/sharp-freebsd-wasm32": 0.35.1
+      "@img/sharp-libvips-darwin-arm64": 1.3.0
+      "@img/sharp-libvips-darwin-x64": 1.3.0
+      "@img/sharp-libvips-linux-arm": 1.3.0
+      "@img/sharp-libvips-linux-arm64": 1.3.0
+      "@img/sharp-libvips-linux-ppc64": 1.3.0
+      "@img/sharp-libvips-linux-riscv64": 1.3.0
+      "@img/sharp-libvips-linux-s390x": 1.3.0
+      "@img/sharp-libvips-linux-x64": 1.3.0
+      "@img/sharp-libvips-linuxmusl-arm64": 1.3.0
+      "@img/sharp-libvips-linuxmusl-x64": 1.3.0
+      "@img/sharp-linux-arm": 0.35.1
+      "@img/sharp-linux-arm64": 0.35.1
+      "@img/sharp-linux-ppc64": 0.35.1
+      "@img/sharp-linux-riscv64": 0.35.1
+      "@img/sharp-linux-s390x": 0.35.1
+      "@img/sharp-linux-x64": 0.35.1
+      "@img/sharp-linuxmusl-arm64": 0.35.1
+      "@img/sharp-linuxmusl-x64": 0.35.1
+      "@img/sharp-webcontainers-wasm32": 0.35.1
+      "@img/sharp-win32-arm64": 0.35.1
+      "@img/sharp-win32-ia32": 0.35.1
+      "@img/sharp-win32-x64": 0.35.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -8170,14 +8346,14 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@3.21.0:
+  shiki@4.2.0:
     dependencies:
-      "@shikijs/core": 3.21.0
-      "@shikijs/engine-javascript": 3.21.0
-      "@shikijs/engine-oniguruma": 3.21.0
-      "@shikijs/langs": 3.21.0
-      "@shikijs/themes": 3.21.0
-      "@shikijs/types": 3.21.0
+      "@shikijs/core": 4.2.0
+      "@shikijs/engine-javascript": 4.2.0
+      "@shikijs/engine-oniguruma": 4.2.0
+      "@shikijs/langs": 4.2.0
+      "@shikijs/themes": 4.2.0
+      "@shikijs/types": 4.2.0
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
@@ -8187,19 +8363,24 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  sitemap@8.0.2:
+  sitemap@9.0.1:
     dependencies:
-      "@types/node": 17.0.45
+      "@types/node": 24.13.2
       "@types/sax": 1.2.7
       arg: 5.0.2
-      sax: 1.4.4
+      sax: 1.6.0
 
   slice-ansi@7.1.2:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  smol-toml@1.6.0: {}
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 
@@ -8211,9 +8392,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.1.0: {}
 
-  stdin-discarder@0.2.2: {}
+  stdin-discarder@0.3.2: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -8228,13 +8409,13 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
-      strip-ansi: 7.1.2
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
-  string-width@8.1.0:
+  string-width@8.2.1:
     dependencies:
-      get-east-asian-width: 1.4.0
-      strip-ansi: 7.1.2
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
   stringify-entities@4.0.4:
     dependencies:
@@ -8245,13 +8426,11 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.1.2:
+  strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
 
   strip-bom-string@1.0.0: {}
-
-  strip-json-comments@3.1.1: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -8268,22 +8447,18 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
-
-  svgo@4.0.0:
+  svgo@4.0.1:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
-      sax: 1.4.4
+      sax: 1.6.0
 
   thenify-all@1.6.0:
     dependencies:
@@ -8297,20 +8472,18 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyclip@0.1.14: {}
+
   tinyexec@0.3.2: {}
 
-  tinyexec@1.0.2: {}
+  tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
-  tinyrainbow@3.0.3: {}
-
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
+  tinyrainbow@3.1.0: {}
 
   tree-kill@1.2.2: {}
 
@@ -8318,89 +8491,67 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-interface-checker@0.1.13: {}
-
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
 
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(postcss@8.5.15)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.2)
+      bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.6)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(postcss@8.5.15)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.56.0
+      rollup: 4.61.1
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.6
-      typescript: 5.9.3
+      postcss: 8.5.15
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  turbo-darwin-64@2.7.6:
-    optional: true
-
-  turbo-darwin-arm64@2.7.6:
-    optional: true
-
-  turbo-linux-64@2.7.6:
-    optional: true
-
-  turbo-linux-arm64@2.7.6:
-    optional: true
-
-  turbo-windows-64@2.7.6:
-    optional: true
-
-  turbo-windows-arm64@2.7.6:
-    optional: true
-
-  turbo@2.7.6:
+  turbo@2.9.18:
     optionalDependencies:
-      turbo-darwin-64: 2.7.6
-      turbo-darwin-arm64: 2.7.6
-      turbo-linux-64: 2.7.6
-      turbo-linux-arm64: 2.7.6
-      turbo-windows-64: 2.7.6
-      turbo-windows-arm64: 2.7.6
+      "@turbo/darwin-64": 2.9.18
+      "@turbo/darwin-arm64": 2.9.18
+      "@turbo/linux-64": 2.9.18
+      "@turbo/linux-arm64": 2.9.18
+      "@turbo/windows-64": 2.9.18
+      "@turbo/windows-arm64": 2.9.18
 
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@4.41.0: {}
+  typescript@6.0.3: {}
 
-  typescript@5.9.3: {}
-
-  ufo@1.6.3: {}
+  ufo@1.6.4: {}
 
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.18.2: {}
+
+  undici-types@7.24.6: {}
 
   unified@11.0.5:
     dependencies:
@@ -8412,9 +8563,9 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unifont@0.7.3:
+  unifont@0.7.4:
     dependencies:
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       ofetch: 1.5.1
       ohash: 2.0.11
 
@@ -8464,16 +8615,16 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unstorage@1.17.4:
+  unstorage@1.17.5:
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.5
-      lru-cache: 11.2.4
+      h3: 1.15.11
+      lru-cache: 11.5.1
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   uri-js@4.4.1:
     dependencies:
@@ -8496,59 +8647,49 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@25.0.10)(yaml@2.8.2):
+  vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.56.0
-      tinyglobby: 0.2.15
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
       fsevents: 2.3.3
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@25.0.10)(yaml@2.8.2)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.0.10)(yaml@2.8.2)
+      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
 
-  vitest@4.0.18(@types/node@25.0.10)(yaml@2.8.2):
+  vitest@4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0)):
     dependencies:
-      "@vitest/expect": 4.0.18
-      "@vitest/mocker": 4.0.18(vite@6.4.1(@types/node@25.0.10)(yaml@2.8.2))
-      "@vitest/pretty-format": 4.0.18
-      "@vitest/runner": 4.0.18
-      "@vitest/snapshot": 4.0.18
-      "@vitest/spy": 4.0.18
-      "@vitest/utils": 4.0.18
-      es-module-lexer: 1.7.0
+      "@vitest/expect": 4.1.8
+      "@vitest/mocker": 4.1.8(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
+      "@vitest/pretty-format": 4.1.8
+      "@vitest/runner": 4.1.8
+      "@vitest/snapshot": 4.1.8
+      "@vitest/spy": 4.1.8
+      "@vitest/utils": 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.2
       pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
+      picomatch: 4.0.4
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@25.0.10)(yaml@2.8.2)
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@types/node": 25.0.10
+      "@types/node": 25.9.3
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   web-namespaces@2.0.1: {}
 
@@ -8563,11 +8704,13 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  widest-line@5.0.0:
-    dependencies:
-      string-width: 7.2.0
-
   word-wrap@1.2.5: {}
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -8579,37 +8722,23 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   xxhash-wasm@1.1.0: {}
 
-  yaml@2.8.2: {}
+  yaml@2.9.0:
+    optional: true
 
-  yargs-parser@21.1.1: {}
+  yargs-parser@22.0.0: {}
 
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
 
-  yocto-spinner@0.2.3:
-    dependencies:
-      yoctocolors: 2.1.2
-
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      typescript: 5.9.3
-      zod: 3.25.76
-
-  zod@3.25.76: {}
-
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/tooling/eslint-config/index.js
+++ b/tooling/eslint-config/index.js
@@ -16,13 +16,13 @@ export default [
       parser: tsparser,
       parserOptions: {
         projectService: {
-          // ** is not allowed here; cover config files at repo root,
-          // package level (apps/cli), and one level deeper
-          allowDefaultProject: [
-            "*.config.ts",
-            "*/*.config.ts",
-            "*/*/*.config.ts",
-          ],
+          // ** is not allowed here. Covers package-root config files for
+          // per-package eslint runs (cwd = package) and apps/*, packages/*
+          // config files for repo-root runs (lint-staged). No deeper glob:
+          // files like apps/docs/src/content.config.ts are already in their
+          // project (Astro's tsconfig includes **/*) and listing them here
+          // would conflict.
+          allowDefaultProject: ["*.config.ts", "*/*/*.config.ts"],
         },
       },
       globals: {

--- a/tooling/eslint-config/index.js
+++ b/tooling/eslint-config/index.js
@@ -15,7 +15,15 @@ export default [
     languageOptions: {
       parser: tsparser,
       parserOptions: {
-        projectService: true,
+        projectService: {
+          // ** is not allowed here; cover config files at repo root,
+          // package level (apps/cli), and one level deeper
+          allowDefaultProject: [
+            "*.config.ts",
+            "*/*.config.ts",
+            "*/*/*.config.ts",
+          ],
+        },
       },
       globals: {
         ...globals.node,

--- a/tooling/eslint-config/package.json
+++ b/tooling/eslint-config/package.json
@@ -8,14 +8,17 @@
     ".": "./index.js"
   },
   "dependencies": {
-    "@eslint/js": "^9.39.0",
-    "@typescript-eslint/eslint-plugin": "^8.53.1",
-    "@typescript-eslint/parser": "^8.53.1",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
-    "globals": "^16.2.0"
+    "@eslint/js": "^10.0.1",
+    "@typescript-eslint/eslint-plugin": "^8.61.0",
+    "@typescript-eslint/parser": "^8.61.0",
+    "eslint-plugin-simple-import-sort": "^13.0.0",
+    "globals": "^17.6.0"
   },
   "peerDependencies": {
-    "eslint": "^9.0.0",
-    "typescript": "^5.0.0"
+    "eslint": "^10.0.0",
+    "typescript": "^5.0.0 || ^6.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^10.4.1"
   }
 }

--- a/tooling/prettier-config/package.json
+++ b/tooling/prettier-config/package.json
@@ -9,5 +9,8 @@
   },
   "peerDependencies": {
     "prettier": "^3.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^10.4.1"
   }
 }

--- a/tooling/prettier-config/package.json
+++ b/tooling/prettier-config/package.json
@@ -9,8 +9,5 @@
   },
   "peerDependencies": {
     "prettier": "^3.0.0"
-  },
-  "devDependencies": {
-    "eslint": "^10.4.1"
   }
 }

--- a/tooling/typescript-config/base.json
+++ b/tooling/typescript-config/base.json
@@ -5,6 +5,7 @@
     "lib": ["ES2023"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "types": ["node"],
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/tooling/typescript-config/package.json
+++ b/tooling/typescript-config/package.json
@@ -8,8 +8,5 @@
     "./base.json": "./base.json",
     "./library.json": "./library.json",
     "./app.json": "./app.json"
-  },
-  "devDependencies": {
-    "eslint": "^10.4.1"
   }
 }

--- a/tooling/typescript-config/package.json
+++ b/tooling/typescript-config/package.json
@@ -8,5 +8,8 @@
     "./base.json": "./base.json",
     "./library.json": "./library.json",
     "./app.json": "./app.json"
+  },
+  "devDependencies": {
+    "eslint": "^10.4.1"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -17,14 +17,17 @@
       "cache": false,
       "persistent": true
     },
+    "topo": {
+      "dependsOn": ["^topo"]
+    },
     "lint": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "topo"]
     },
     "lint:fix": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "topo"]
     },
     "typecheck": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "topo"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## Summary

Full dependency maintenance pass: every dependency is now current (`pnpm outdated` is empty) and `pnpm audit` reports **0 vulnerabilities** (was 34: 15 high, 14 moderate, 5 low — nearly all in the docs site's Astro 5 tree).

### Major upgrades
- TypeScript 6, ESLint 10, Astro 6 + Starlight 0.40
- commander 15, @inquirer/prompts 8, lint-staged 17, globals 17, eslint-plugin-simple-import-sort 13, sharp 0.35
- Plus all in-range minor/patch bumps (zod, vitest, turbo, ora, prettier, typescript-eslint, etc.)

### Migration fixes
- Starlight 0.39+ sidebar `autogenerate` syntax in `astro.config.mjs`
- `"types": ["node"]` in shared tsconfig (TS 6 no longer auto-includes `@types` packages)
- Silence tsup-injected `baseUrl` deprecation (TS5101) in core DTS build
- Allow `*.config.ts` in the ESLint project service default project (fixes pre-existing pre-commit failure on config files)

### CI hardening
- New `.github/dependabot.yml`: weekly npm updates with minor/patch grouped into one PR, plus github-actions updates
- CI now fails on high-severity production vulnerabilities (`pnpm audit --prod --audit-level high`)

## Test plan
- [x] `pnpm build` / `pnpm typecheck` / `pnpm lint` / `pnpm format:check` all pass
- [x] All 545 tests pass (505 core + 40 cli)
- [x] `pnpm audit` clean (prod and dev)
- [x] Smoke-tested built CLI: `--help` and `lnai sync --dry-run` work (commander 15 / inquirer 8 runtime OK)
- [x] Docs site builds (19 pages, Astro 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs a production dependency security audit as part of the pipeline.
  * Dependabot configured to check npm and GitHub Actions weekly with grouped npm updates.
  * Repository tooling, lint/typecheck, and build configs updated and improved.
  * Pre-commit checks expanded to include dependency analysis.
* **Release**
  * CLI package version bumped to 0.6.92.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->