### PR TITLE
feat: sync MCP OAuth settings from settings.json to native tool configs

### DIFF
--- a/apps/docs/src/content/docs/reference/configuration.md
+++ b/apps/docs/src/content/docs/reference/configuration.md
@@ -157,4 +157,34 @@ Configure Model Context Protocol servers.
 }
 ```
 
+### OAuth
+
+Remote servers that require a statically-registered OAuth client can configure it under `oauth`:
+
+```json
+{
+  "mcpServers": {
+    "api": {
+      "type": "http",
+      "url": "https://mcp.example.com",
+      "oauth": {
+        "clientId": "client-123",
+        "clientSecret": "${OAUTH_CLIENT_SECRET}",
+        "callbackPort": 8080,
+        "scopes": ["read", "write"]
+      }
+    }
+  }
+}
+```
+
+| Field          | Required | Description                                      |
+| -------------- | -------- | ------------------------------------------------ |
+| `clientId`     | Yes      | OAuth client ID                                  |
+| `clientSecret` | No       | OAuth client secret                              |
+| `callbackPort` | No       | Fixed local port for the OAuth redirect callback |
+| `scopes`       | No       | OAuth scopes to request during authorization     |
+
+Not every tool's native MCP format supports every field - see each tool's page under [Supported Tools](/tools/claude-code/) for what's synced and what's skipped with a warning.
+
 Use `${VAR}` syntax for environment variables.

--- a/apps/docs/src/content/docs/tools/claude-code.md
+++ b/apps/docs/src/content/docs/tools/claude-code.md
@@ -59,3 +59,5 @@ MCP servers are written to `.mcp.json` at the project root (not inside `.claude/
   }
 }
 ```
+
+`oauth` (`clientId`, `clientSecret`, `callbackPort`, `scopes`) on a remote server is copied through as-is, since Claude Code's own MCP format is the source of truth for this field.

--- a/apps/docs/src/content/docs/tools/codex.md
+++ b/apps/docs/src/content/docs/tools/codex.md
@@ -65,6 +65,45 @@ url = "https://mcp.example.com"
 http_headers = { Authorization = "Bearer ${API_KEY}" }
 ```
 
+`clientId` is synced into a nested `[mcp_servers.<name>.oauth]` table, and `scopes` as a sibling key at the server level (not nested inside `oauth` - Codex's per-server oauth table only has room for `client_id`):
+
+```json
+// Input (LNAI format)
+{
+  "mcpServers": {
+    "my-remote-server": {
+      "url": "https://mcp.example.com",
+      "oauth": {
+        "clientId": "client-123",
+        "callbackPort": 8080,
+        "scopes": ["read", "write"]
+      }
+    }
+  }
+}
+```
+
+```toml
+# Output (Codex format)
+mcp_oauth_callback_port = 8080
+
+[mcp_servers.my-remote-server]
+url = "https://mcp.example.com"
+scopes = ["read", "write"]
+
+[mcp_servers.my-remote-server.oauth]
+client_id = "client-123"
+```
+
+| LNAI           | Codex                                              |
+| -------------- | -------------------------------------------------- |
+| `clientId`     | `client_id` under `[mcp_servers.<name>.oauth]`     |
+| `scopes`       | `scopes` on `[mcp_servers.<name>]` itself          |
+| `callbackPort` | `mcp_oauth_callback_port` (global, root-level key) |
+| `clientSecret` | ⚠️ Not supported by Codex - skipped with a warning |
+
+`callbackPort` has no per-server equivalent in Codex - it's a single global setting shared by every MCP server's OAuth flow. If multiple servers configure different `callbackPort` values, LNAI uses the first one and warns about the rest, since Codex can't apply more than one.
+
 ## Rules
 
 Rules are grouped by directory using their `paths` globs and written to

--- a/apps/docs/src/content/docs/tools/copilot.md
+++ b/apps/docs/src/content/docs/tools/copilot.md
@@ -101,6 +101,8 @@ MCP servers are exported to `.vscode/mcp.json` with transformations:
 | `type: "sse"`  | `url` field only (no type)     |
 | `headers: {}`  | `requestInit: { headers: {} }` |
 
+Only `oauth.clientId` is copied to a matching `oauth` object - it's the only field Copilot's `mcp.json` format supports. `clientSecret`, `callbackPort`, and `scopes` have no equivalent there and are skipped with a warning.
+
 ## Rules Transformation
 
 Rules are transformed from `.md` to `.instructions.md` format with YAML frontmatter:

--- a/apps/docs/src/content/docs/tools/cursor.md
+++ b/apps/docs/src/content/docs/tools/cursor.md
@@ -64,6 +64,8 @@ MCP servers are exported to `.cursor/mcp.json` with environment variable transfo
 | `type: "http"` | `url` field only |
 | `type: "sse"`  | `url` field only |
 
+`oauth` on a remote server maps to Cursor's static `auth` object: `clientId` → `CLIENT_ID`, `clientSecret` → `CLIENT_SECRET`, `scopes` → `scopes`. `callbackPort` has no equivalent in Cursor's format and is skipped with a warning.
+
 ## Generated cli.json
 
 Permissions are exported to `.cursor/cli.json` with transformations:

--- a/apps/docs/src/content/docs/tools/gemini-cli.md
+++ b/apps/docs/src/content/docs/tools/gemini-cli.md
@@ -77,6 +77,8 @@ HTTP/SSE servers use `httpUrl` instead of `url`:
 | ----- | ---------- |
 | `url` | `httpUrl`  |
 
+`oauth` on a remote server maps to Gemini CLI's `oauth` object with `enabled: true` plus `clientId`, `clientSecret`, and `scopes` passed through as-is. `callbackPort` has no equivalent in Gemini CLI's format and is skipped with a warning.
+
 ### Rules
 
 Rules are grouped by their target directory and combined into `GEMINI.md` files:

--- a/apps/docs/src/content/docs/tools/opencode.md
+++ b/apps/docs/src/content/docs/tools/opencode.md
@@ -61,4 +61,6 @@ opencode.json          # Generated (at project root)
 | `env: {}`                 | `environment: {}`                 |
 | `${VAR}`                  | `{env:VAR}`                       |
 
+`oauth` on a remote server maps to OpenCode's `oauth` object: `clientId`, `clientSecret`, and `callbackPort` pass through as-is, and `scopes` is joined into a single space-separated `scope` string.
+
 Place OpenCode-specific files in `.ai/.opencode/` to have them symlinked to `.opencode/`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
 // Schemas
 export {
   configSchema,
+  mcpOAuthSchema,
   mcpServerSchema,
   permissionsSchema,
   ruleFrontmatterSchema,
@@ -39,6 +40,7 @@ export type {
   ManifestEntry,
   MarkdownFile,
   MarkdownFrontmatter,
+  McpOAuth,
   McpServer,
   OutputFile,
   PermissionLevel,

--- a/packages/core/src/plugins/claude-code/index.test.ts
+++ b/packages/core/src/plugins/claude-code/index.test.ts
@@ -167,6 +167,34 @@ describe("claudeCodePlugin", () => {
       ).toBeUndefined();
     });
 
+    it("syncs oauth settings through to .mcp.json", async () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            api: {
+              type: "http",
+              url: "https://api.example.com/mcp",
+              oauth: {
+                clientId: "client-123",
+                callbackPort: 8080,
+              },
+            },
+          },
+        },
+      });
+
+      const files = await claudeCodePlugin.export(state, tempDir);
+
+      const mcpJson = files.find((f) => f.path === ".mcp.json");
+      const mcpServers = (mcpJson?.content as Record<string, unknown>)[
+        "mcpServers"
+      ] as Record<string, { oauth?: unknown }>;
+      expect(mcpServers["api"]?.oauth).toEqual({
+        clientId: "client-123",
+        callbackPort: 8080,
+      });
+    });
+
     it("skips .mcp.json when mcpServers is empty", async () => {
       const state = createMinimalState({
         settings: {

--- a/packages/core/src/plugins/codex/index.test.ts
+++ b/packages/core/src/plugins/codex/index.test.ts
@@ -109,6 +109,92 @@ describe("codexPlugin", () => {
       );
     });
 
+    it("syncs client_id into a nested [mcp_servers.<name>.oauth] table and scopes as a sibling key", async () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            "my-remote-server": {
+              url: "http://localhost:3000",
+              oauth: {
+                clientId: "client-123",
+                clientSecret: "shh-its-a-secret",
+                callbackPort: 8080,
+                scopes: ["read", "write"],
+              },
+            },
+          },
+        },
+      });
+
+      const files = await codexPlugin.export(state, tempDir);
+
+      const configToml = files.find((f) => f.path === ".codex/config.toml");
+      const content = String(configToml?.content);
+      // The callback port is a single global setting in Codex, written as a
+      // root-level key before any [mcp_servers.*] table headers
+      expect(content).toContain("mcp_oauth_callback_port = 8080");
+      expect(content.indexOf("mcp_oauth_callback_port")).toBeLessThan(
+        content.indexOf("[mcp_servers.")
+      );
+      // `scopes` is a sibling of `oauth` under [mcp_servers.<name>], not nested inside it
+      expect(content).toMatch(
+        /\[mcp_servers\.my-remote-server\]\nurl = "http:\/\/localhost:3000"\nscopes = \["read", "write"\]/
+      );
+      expect(content).toContain("[mcp_servers.my-remote-server.oauth]");
+      expect(content).toContain('client_id = "client-123"');
+      // Codex's per-server oauth table has no client_secret field
+      expect(content).not.toContain("client_secret");
+      // callback_port is not a per-server field under [mcp_servers.*.oauth]
+      expect(content).not.toMatch(/\ncallback_port =/);
+    });
+
+    it("omits scopes when not provided", async () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            remote: {
+              url: "http://localhost:3000",
+              oauth: { clientId: "client-123" },
+            },
+          },
+        },
+      });
+
+      const files = await codexPlugin.export(state, tempDir);
+
+      const configToml = files.find((f) => f.path === ".codex/config.toml");
+      const content = String(configToml?.content);
+      expect(content).toContain("[mcp_servers.remote.oauth]");
+      expect(content).toContain('client_id = "client-123"');
+      expect(content).not.toContain("mcp_oauth_callback_port");
+      expect(content).not.toContain("client_secret");
+      expect(content).not.toContain("scopes");
+    });
+
+    it("uses the first callbackPort when multiple servers disagree", async () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            first: {
+              url: "http://localhost:3000",
+              oauth: { clientId: "client-1", callbackPort: 8080 },
+            },
+            second: {
+              url: "http://localhost:4000",
+              oauth: { clientId: "client-2", callbackPort: 9090 },
+            },
+          },
+        },
+      });
+
+      const files = await codexPlugin.export(state, tempDir);
+
+      const configToml = files.find((f) => f.path === ".codex/config.toml");
+      const content = String(configToml?.content);
+      expect(content).toContain("mcp_oauth_callback_port = 8080");
+      expect(content).not.toContain("mcp_oauth_callback_port = 9090");
+    });
+
     it("creates skill symlinks", async () => {
       const state = createMinimalState({
         skills: [
@@ -163,6 +249,78 @@ describe("codexPlugin", () => {
       expect(result.skipped.some((s) => s.feature === "permissions")).toBe(
         true
       );
+    });
+
+    it("warns when MCP servers request conflicting OAuth callback ports", () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            first: {
+              url: "http://localhost:3000",
+              oauth: { clientId: "client-1", callbackPort: 8080 },
+            },
+            second: {
+              url: "http://localhost:4000",
+              oauth: { clientId: "client-2", callbackPort: 9090 },
+            },
+          },
+        },
+      });
+
+      const result = codexPlugin.validate(state);
+
+      const portWarning = result.warnings.find((w) =>
+        w.message.includes("callbackPort")
+      );
+      expect(portWarning).toBeDefined();
+      expect(portWarning?.message).toContain("8080");
+      expect(portWarning?.message).toContain("9090");
+      expect(portWarning?.message).toContain("mcp_oauth_callback_port");
+    });
+
+    it("no warning when servers agree on the same callback port", () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            first: {
+              url: "http://localhost:3000",
+              oauth: { clientId: "client-1", callbackPort: 8080 },
+            },
+            second: {
+              url: "http://localhost:4000",
+              oauth: { clientId: "client-2", callbackPort: 8080 },
+            },
+          },
+        },
+      });
+
+      const result = codexPlugin.validate(state);
+
+      const portWarning = result.warnings.find((w) =>
+        w.message.includes("callbackPort")
+      );
+      expect(portWarning).toBeUndefined();
+    });
+
+    it("warns that Codex's oauth table has no clientSecret field", () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            api: {
+              url: "http://localhost:3000",
+              oauth: { clientId: "client-123", clientSecret: "shh" },
+            },
+          },
+        },
+      });
+
+      const result = codexPlugin.validate(state);
+
+      const secretWarning = result.warnings.find((w) =>
+        w.message.includes("clientSecret")
+      );
+      expect(secretWarning).toBeDefined();
+      expect(secretWarning?.message).toContain("Codex");
     });
   });
 });

--- a/packages/core/src/plugins/codex/index.ts
+++ b/packages/core/src/plugins/codex/index.ts
@@ -13,6 +13,7 @@ import {
   createSkillSymlinks,
   hasPermissionsConfigured,
 } from "../../utils/agents";
+import { validateOAuthFieldSupport } from "../../utils/mcp";
 import { applyFileOverrides } from "../../utils/overrides";
 import { groupRulesByDirectory } from "../../utils/rules";
 import type { Plugin } from "../types";
@@ -114,6 +115,26 @@ export const codexPlugin: Plugin = {
       });
     }
 
+    if (mcpServers) {
+      const callbackPorts = getOAuthCallbackPorts(mcpServers);
+      if (callbackPorts.length > 1) {
+        warnings.push({
+          path: ["settings", "mcpServers"],
+          message: `Multiple MCP servers request different OAuth callbackPort values (${callbackPorts.join(", ")}) - Codex only supports one global mcp_oauth_callback_port, so only ${callbackPorts[0]} will be applied`,
+        });
+      }
+    }
+
+    // Codex's per-server oauth table only has a `client_id` field
+    warnings.push(
+      ...validateOAuthFieldSupport(
+        state.settings?.mcpServers,
+        ["settings", "mcpServers"],
+        "Codex",
+        ["clientSecret"]
+      )
+    );
+
     return { valid: true, errors: [], warnings, skipped };
   },
 };
@@ -154,6 +175,18 @@ function buildCodexConfigToml(
       }
     }
 
+    if (server.oauth) {
+      // `scopes` is a sibling of `oauth`, not nested inside it - Codex's
+      // per-server oauth table only accepts `client_id`
+      if (server.oauth.scopes && server.oauth.scopes.length > 0) {
+        lines.push(`scopes = ${formatTomlArray(server.oauth.scopes)}`);
+      }
+
+      lines.push("");
+      lines.push(`[mcp_servers.${formatTomlKey(name)}.oauth]`);
+      lines.push(`client_id = ${formatTomlString(server.oauth.clientId)}`);
+    }
+
     lines.push("");
   }
 
@@ -161,7 +194,36 @@ function buildCodexConfigToml(
     return undefined;
   }
 
+  // `mcp_oauth_callback_port` is a single global setting in Codex, not
+  // per-server, so it must be a root-level key written before any
+  // [mcp_servers.*] table headers.
+  const callbackPorts = getOAuthCallbackPorts(mcpServers);
+  if (callbackPorts.length > 0) {
+    lines.unshift(`mcp_oauth_callback_port = ${callbackPorts[0]}`, "");
+  }
+
   return `${lines.join("\n").trimEnd()}\n`;
+}
+
+/**
+ * Collect the distinct OAuth callback ports requested across MCP servers,
+ * in first-seen order. Codex only supports one global callback port
+ * (`mcp_oauth_callback_port`), so more than one distinct value here means
+ * a conflict - only the first is applied.
+ */
+function getOAuthCallbackPorts(
+  mcpServers: Record<string, McpServer>
+): number[] {
+  const ports: number[] = [];
+
+  for (const server of Object.values(mcpServers)) {
+    const port = server.oauth?.callbackPort;
+    if (port !== undefined && !ports.includes(port)) {
+      ports.push(port);
+    }
+  }
+
+  return ports;
 }
 
 function formatTomlString(value: string): string {

--- a/packages/core/src/plugins/copilot/index.test.ts
+++ b/packages/core/src/plugins/copilot/index.test.ts
@@ -521,6 +521,34 @@ describe("copilotPlugin", () => {
       expect(mcpWarning?.message).toContain("will be skipped");
     });
 
+    it("warns when an MCP server has OAuth clientSecret/callbackPort/scopes configured", () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            api: {
+              type: "http",
+              url: "https://api.example.com/mcp",
+              oauth: {
+                clientId: "client-123",
+                clientSecret: "shh",
+                callbackPort: 8080,
+                scopes: ["read"],
+              },
+            },
+          },
+        },
+      });
+
+      const result = copilotPlugin.validate(state);
+
+      const oauthWarning = result.warnings.find((w) =>
+        w.message.includes("clientSecret")
+      );
+      expect(oauthWarning).toBeDefined();
+      expect(oauthWarning?.message).toContain("callbackPort");
+      expect(oauthWarning?.message).toContain("GitHub Copilot");
+    });
+
     it("no skipped features", () => {
       const state = createMinimalState({
         skills: [

--- a/packages/core/src/plugins/copilot/index.ts
+++ b/packages/core/src/plugins/copilot/index.ts
@@ -12,7 +12,7 @@ import {
   createSkillSymlinks,
   hasPermissionsConfigured,
 } from "../../utils/agents";
-import { validateMcpServers } from "../../utils/mcp";
+import { validateMcpServers, validateOAuthFieldSupport } from "../../utils/mcp";
 import { applyFileOverrides } from "../../utils/overrides";
 import type { Plugin } from "../types";
 import {
@@ -111,6 +111,16 @@ export const copilotPlugin: Plugin = {
         "settings",
         "mcpServers",
       ])
+    );
+
+    // Copilot's OAuth config only has a clientId setting
+    warnings.push(
+      ...validateOAuthFieldSupport(
+        state.settings?.mcpServers,
+        ["settings", "mcpServers"],
+        "GitHub Copilot",
+        ["clientSecret", "callbackPort", "scopes"]
+      )
     );
 
     return { valid: true, errors: [], warnings, skipped };

--- a/packages/core/src/plugins/copilot/transforms.test.ts
+++ b/packages/core/src/plugins/copilot/transforms.test.ts
@@ -249,6 +249,21 @@ describe("transformMcpToCopilot", () => {
         },
       });
     });
+
+    it("converts oauth to clientId only", () => {
+      const result = transformMcpToCopilot({
+        api: {
+          type: "http",
+          url: "https://api.example.com/mcp",
+          oauth: { clientId: "client-123", callbackPort: 8080 },
+        },
+      });
+
+      expect(result?.servers["api"]).toEqual({
+        url: "https://api.example.com/mcp",
+        oauth: { clientId: "client-123" },
+      });
+    });
   });
 
   describe("sse servers", () => {

--- a/packages/core/src/plugins/copilot/transforms.ts
+++ b/packages/core/src/plugins/copilot/transforms.ts
@@ -95,6 +95,9 @@ export function transformMcpToCopilot(
           headers: transformEnvVars(server.headers, "copilot"),
         };
       }
+      if (server.oauth) {
+        copilotServer.oauth = { clientId: server.oauth.clientId };
+      }
       result[name] = copilotServer;
     } else if (server.command) {
       // Stdio server

--- a/packages/core/src/plugins/copilot/types.ts
+++ b/packages/core/src/plugins/copilot/types.ts
@@ -17,6 +17,9 @@ export interface CopilotMcpRemoteServer {
   requestInit?: {
     headers?: Record<string, string>;
   };
+  oauth?: {
+    clientId: string;
+  };
 }
 
 export type CopilotMcpServer = CopilotMcpStdioServer | CopilotMcpRemoteServer;

--- a/packages/core/src/plugins/cursor/index.test.ts
+++ b/packages/core/src/plugins/cursor/index.test.ts
@@ -469,6 +469,28 @@ describe("cursorPlugin", () => {
       expect(askWarning?.message).toContain("allow");
     });
 
+    it("warns when an MCP server has OAuth callbackPort configured", () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            api: {
+              type: "http",
+              url: "https://api.example.com/mcp",
+              oauth: { clientId: "client-123", callbackPort: 8080 },
+            },
+          },
+        },
+      });
+
+      const result = cursorPlugin.validate(state);
+
+      const oauthWarning = result.warnings.find((w) =>
+        w.message.includes("callbackPort")
+      );
+      expect(oauthWarning).toBeDefined();
+      expect(oauthWarning?.message).toContain("Cursor");
+    });
+
     it("no warning when only allow and deny permissions", () => {
       const state = createMinimalState({
         settings: {

--- a/packages/core/src/plugins/cursor/index.ts
+++ b/packages/core/src/plugins/cursor/index.ts
@@ -11,7 +11,7 @@ import {
   createRootAgentsMdSymlink,
   createSkillSymlinks,
 } from "../../utils/agents";
-import { validateMcpServers } from "../../utils/mcp";
+import { validateMcpServers, validateOAuthFieldSupport } from "../../utils/mcp";
 import { applyFileOverrides } from "../../utils/overrides";
 import type { Plugin } from "../types";
 import {
@@ -124,6 +124,16 @@ export const cursorPlugin: Plugin = {
         "settings",
         "mcpServers",
       ])
+    );
+
+    // Cursor's static OAuth config has no callback port setting
+    warnings.push(
+      ...validateOAuthFieldSupport(
+        state.settings?.mcpServers,
+        ["settings", "mcpServers"],
+        "Cursor",
+        ["callbackPort"]
+      )
     );
 
     return { valid: true, errors: [], warnings, skipped: [] };

--- a/packages/core/src/plugins/cursor/transforms.test.ts
+++ b/packages/core/src/plugins/cursor/transforms.test.ts
@@ -282,6 +282,49 @@ describe("transformMcpToCursor", () => {
       );
       expect(result?.["api"]?.headers?.["X-Custom"]).toBe("static-value");
     });
+
+    it("converts oauth to auth with uppercase keys", () => {
+      const result = transformMcpToCursor({
+        api: {
+          type: "http",
+          url: "https://api.example.com/mcp",
+          oauth: {
+            clientId: "client-123",
+            clientSecret: "secret-456",
+            scopes: ["read", "write"],
+          },
+        },
+      });
+
+      expect(result?.["api"]?.auth).toEqual({
+        CLIENT_ID: "client-123",
+        CLIENT_SECRET: "secret-456",
+        scopes: ["read", "write"],
+      });
+    });
+
+    it("omits CLIENT_SECRET and scopes when not provided", () => {
+      const result = transformMcpToCursor({
+        api: {
+          type: "http",
+          url: "https://api.example.com/mcp",
+          oauth: { clientId: "client-123" },
+        },
+      });
+
+      expect(result?.["api"]?.auth).toEqual({ CLIENT_ID: "client-123" });
+    });
+
+    it("does not set auth when no oauth configured", () => {
+      const result = transformMcpToCursor({
+        api: {
+          type: "http",
+          url: "https://api.example.com/mcp",
+        },
+      });
+
+      expect(result?.["api"]?.auth).toBeUndefined();
+    });
   });
 
   describe("sse servers", () => {

--- a/packages/core/src/plugins/cursor/transforms.ts
+++ b/packages/core/src/plugins/cursor/transforms.ts
@@ -91,6 +91,17 @@ export function transformMcpToCursor(
       if (server.headers) {
         cursorServer.headers = transformEnvVars(server.headers, "cursor");
       }
+      if (server.oauth) {
+        cursorServer.auth = {
+          CLIENT_ID: server.oauth.clientId,
+          ...(server.oauth.clientSecret !== undefined && {
+            CLIENT_SECRET: server.oauth.clientSecret,
+          }),
+          ...(server.oauth.scopes !== undefined && {
+            scopes: server.oauth.scopes,
+          }),
+        };
+      }
       result[name] = cursorServer;
     } else if (server.command) {
       const cursorServer: CursorMcpServer = {

--- a/packages/core/src/plugins/cursor/types.ts
+++ b/packages/core/src/plugins/cursor/types.ts
@@ -4,6 +4,13 @@ export interface CursorRuleFrontmatter {
   alwaysApply: boolean;
 }
 
+/** Cursor-specific static OAuth config for remote servers */
+interface CursorMcpAuth {
+  CLIENT_ID: string;
+  CLIENT_SECRET?: string;
+  scopes?: string[];
+}
+
 /** Cursor-specific MCP server output format */
 export interface CursorMcpServer {
   command?: string;
@@ -11,6 +18,7 @@ export interface CursorMcpServer {
   env?: Record<string, string>;
   url?: string;
   headers?: Record<string, string>;
+  auth?: CursorMcpAuth;
 }
 
 interface CursorPermissions {

--- a/packages/core/src/plugins/gemini/index.test.ts
+++ b/packages/core/src/plugins/gemini/index.test.ts
@@ -328,6 +328,28 @@ describe("geminiPlugin", () => {
         true
       );
     });
+
+    it("warns when an MCP server has OAuth callbackPort configured", () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            api: {
+              type: "http",
+              url: "https://api.example.com/mcp",
+              oauth: { clientId: "client-123", callbackPort: 8080 },
+            },
+          },
+        },
+      });
+
+      const result = geminiPlugin.validate(state);
+
+      const oauthWarning = result.warnings.find((w) =>
+        w.message.includes("callbackPort")
+      );
+      expect(oauthWarning).toBeDefined();
+      expect(oauthWarning?.message).toContain("Gemini CLI");
+    });
   });
 
   describe("detect", () => {

--- a/packages/core/src/plugins/gemini/index.ts
+++ b/packages/core/src/plugins/gemini/index.ts
@@ -12,6 +12,7 @@ import {
   createSkillSymlinks,
   hasPermissionsConfigured,
 } from "../../utils/agents";
+import { validateOAuthFieldSupport } from "../../utils/mcp";
 import { applyFileOverrides } from "../../utils/overrides";
 import { groupRulesByDirectory } from "../../utils/rules";
 import type { Plugin } from "../types";
@@ -112,6 +113,16 @@ export const geminiPlugin: Plugin = {
           "Rules will be generated into GEMINI.md files in their respective subdirectories (e.g. apps/cli/GEMINI.md).",
       });
     }
+
+    // Gemini CLI's OAuth config has no callback port setting
+    warnings.push(
+      ...validateOAuthFieldSupport(
+        state.settings?.mcpServers,
+        ["settings", "mcpServers"],
+        "Gemini CLI",
+        ["callbackPort"]
+      )
+    );
 
     return { valid: true, errors: [], warnings, skipped };
   },

--- a/packages/core/src/plugins/gemini/transforms.test.ts
+++ b/packages/core/src/plugins/gemini/transforms.test.ts
@@ -57,6 +57,44 @@ describe("transformMcpToGemini", () => {
 
     expect(transformMcpToGemini(input)).toEqual(expected);
   });
+
+  it("should convert oauth to enabled clientId/clientSecret/scopes", () => {
+    const input = {
+      server1: {
+        url: "http://localhost:3000",
+        oauth: {
+          clientId: "client-123",
+          clientSecret: "secret-456",
+          scopes: ["read", "write"],
+        },
+      },
+    };
+
+    const result = transformMcpToGemini(input);
+
+    expect(result?.["server1"]?.oauth).toEqual({
+      enabled: true,
+      clientId: "client-123",
+      clientSecret: "secret-456",
+      scopes: ["read", "write"],
+    });
+  });
+
+  it("should omit clientSecret and scopes when not provided", () => {
+    const input = {
+      server1: {
+        url: "http://localhost:3000",
+        oauth: { clientId: "client-123" },
+      },
+    };
+
+    const result = transformMcpToGemini(input);
+
+    expect(result?.["server1"]?.oauth).toEqual({
+      enabled: true,
+      clientId: "client-123",
+    });
+  });
 });
 
 describe("groupRulesByDirectory", () => {

--- a/packages/core/src/plugins/gemini/transforms.ts
+++ b/packages/core/src/plugins/gemini/transforms.ts
@@ -24,6 +24,19 @@ export function transformMcpToGemini(
     if (config.url) {
       geminiMcp[name].httpUrl = config.url;
     }
+
+    if (config.oauth) {
+      geminiMcp[name].oauth = {
+        enabled: true,
+        clientId: config.oauth.clientId,
+        ...(config.oauth.clientSecret !== undefined && {
+          clientSecret: config.oauth.clientSecret,
+        }),
+        ...(config.oauth.scopes !== undefined && {
+          scopes: config.oauth.scopes,
+        }),
+      };
+    }
   }
 
   return Object.keys(geminiMcp).length > 0 ? geminiMcp : undefined;

--- a/packages/core/src/plugins/gemini/types.ts
+++ b/packages/core/src/plugins/gemini/types.ts
@@ -1,8 +1,16 @@
+interface GeminiMcpOAuth {
+  enabled: true;
+  clientId: string;
+  clientSecret?: string;
+  scopes?: string[];
+}
+
 interface GeminiMcpServer {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
   httpUrl?: string;
+  oauth?: GeminiMcpOAuth;
 }
 
 export interface GeminiMcpSettings {

--- a/packages/core/src/plugins/opencode/index.test.ts
+++ b/packages/core/src/plugins/opencode/index.test.ts
@@ -155,6 +155,30 @@ describe("opencodePlugin", () => {
       expect(mcp["db"]?.["command"]).toEqual(["npx", "-y", "@example/db"]);
     });
 
+    it("syncs oauth settings including callbackPort", async () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            api: {
+              type: "http",
+              url: "https://api.example.com/mcp",
+              oauth: { clientId: "client-123", callbackPort: 8080 },
+            },
+          },
+        },
+      });
+
+      const files = await opencodePlugin.export(state, tempDir);
+
+      const config = files.find((f) => f.path === "opencode.json");
+      const content = config?.content as Record<string, unknown>;
+      const mcp = content["mcp"] as Record<string, Record<string, unknown>>;
+      expect(mcp["api"]?.["oauth"]).toEqual({
+        clientId: "client-123",
+        callbackPort: 8080,
+      });
+    });
+
     it("transforms and adds permissions", async () => {
       const state = createMinimalState({
         settings: {
@@ -293,6 +317,32 @@ describe("opencodePlugin", () => {
       const result = opencodePlugin.validate(state);
 
       expect(result.skipped).toHaveLength(0);
+    });
+
+    it("no warning for OAuth fields since OpenCode supports clientId/clientSecret/scopes/callbackPort", () => {
+      const state = createMinimalState({
+        settings: {
+          mcpServers: {
+            api: {
+              type: "http",
+              url: "https://api.example.com/mcp",
+              oauth: {
+                clientId: "client-123",
+                clientSecret: "shh",
+                callbackPort: 8080,
+                scopes: ["read"],
+              },
+            },
+          },
+        },
+      });
+
+      const result = opencodePlugin.validate(state);
+
+      const oauthWarning = result.warnings.find((w) =>
+        w.message.includes("OAuth")
+      );
+      expect(oauthWarning).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/plugins/opencode/transforms.test.ts
+++ b/packages/core/src/plugins/opencode/transforms.test.ts
@@ -90,6 +90,40 @@ describe("transformMcpToOpenCode", () => {
       expect(result?.["api"]?.headers?.["Authorization"]).toBe("Bearer token");
       expect(result?.["api"]?.headers?.["X-Custom"]).toBe("value");
     });
+
+    it("converts oauth clientId/clientSecret/callbackPort and joins scopes into scope", () => {
+      const result = transformMcpToOpenCode({
+        api: {
+          type: "http",
+          url: "https://api.example.com/mcp",
+          oauth: {
+            clientId: "client-123",
+            clientSecret: "secret-456",
+            scopes: ["read", "write"],
+            callbackPort: 8080,
+          },
+        },
+      });
+
+      expect(result?.["api"]?.oauth).toEqual({
+        clientId: "client-123",
+        clientSecret: "secret-456",
+        scope: "read write",
+        callbackPort: 8080,
+      });
+    });
+
+    it("omits clientSecret and scope when not provided", () => {
+      const result = transformMcpToOpenCode({
+        api: {
+          type: "http",
+          url: "https://api.example.com/mcp",
+          oauth: { clientId: "client-123" },
+        },
+      });
+
+      expect(result?.["api"]?.oauth).toEqual({ clientId: "client-123" });
+    });
   });
 
   describe("sse servers", () => {

--- a/packages/core/src/plugins/opencode/transforms.ts
+++ b/packages/core/src/plugins/opencode/transforms.ts
@@ -31,6 +31,20 @@ export function transformMcpToOpenCode(
       if (server.headers) {
         openCodeServer.headers = server.headers;
       }
+      if (server.oauth) {
+        openCodeServer.oauth = {
+          clientId: server.oauth.clientId,
+          ...(server.oauth.clientSecret !== undefined && {
+            clientSecret: server.oauth.clientSecret,
+          }),
+          ...(server.oauth.scopes !== undefined && {
+            scope: server.oauth.scopes.join(" "),
+          }),
+          ...(server.oauth.callbackPort !== undefined && {
+            callbackPort: server.oauth.callbackPort,
+          }),
+        };
+      }
       result[name] = openCodeServer;
     } else if (server.command) {
       const command = [server.command, ...(server.args || [])];

--- a/packages/core/src/plugins/opencode/types.ts
+++ b/packages/core/src/plugins/opencode/types.ts
@@ -1,3 +1,11 @@
+/** OpenCode-specific static OAuth config for remote servers */
+interface OpenCodeMcpOAuth {
+  clientId: string;
+  clientSecret?: string;
+  scope?: string;
+  callbackPort?: number;
+}
+
 /** OpenCode-specific MCP server output format */
 export interface OpenCodeMcpServer {
   type: "local" | "remote";
@@ -5,6 +13,7 @@ export interface OpenCodeMcpServer {
   url?: string;
   environment?: Record<string, string>;
   headers?: Record<string, string>;
+  oauth?: OpenCodeMcpOAuth;
 }
 
 export type OpenCodePermission = Record<

--- a/packages/core/src/schemas/index.test.ts
+++ b/packages/core/src/schemas/index.test.ts
@@ -54,6 +54,41 @@ describe("mcpServerSchema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("validates config with full oauth settings", () => {
+    const result = mcpServerSchema.safeParse({
+      type: "http",
+      url: "https://api.example.com/mcp",
+      oauth: {
+        clientId: "client-123",
+        clientSecret: "shh-its-a-secret",
+        callbackPort: 8080,
+        scopes: ["read", "write"],
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("validates oauth with only clientId", () => {
+    const result = mcpServerSchema.safeParse({
+      type: "http",
+      url: "https://api.example.com/mcp",
+      oauth: { clientId: "client-123" },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects oauth missing clientId", () => {
+    const result = mcpServerSchema.safeParse({
+      type: "http",
+      url: "https://api.example.com/mcp",
+      oauth: { callbackPort: 8080 },
+    });
+
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("permissionsSchema", () => {

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+/** MCP Server OAuth configuration (Claude format as source of truth) */
+export const mcpOAuthSchema = z.object({
+  clientId: z.string(),
+  clientSecret: z.string().optional(),
+  callbackPort: z.number().optional(),
+  scopes: z.array(z.string()).optional(),
+});
+
 /** MCP Server configuration (Claude format as source of truth) */
 export const mcpServerSchema = z.object({
   command: z.string().optional(),
@@ -8,6 +16,7 @@ export const mcpServerSchema = z.object({
   type: z.enum(["http", "sse"]).optional(),
   url: z.string().optional(),
   headers: z.record(z.string(), z.string()).optional(),
+  oauth: mcpOAuthSchema.optional(),
 });
 
 export const permissionsSchema = z.object({
@@ -64,6 +73,7 @@ export const ruleFrontmatterSchema = z.object({
   paths: z.array(z.string()).min(1),
 });
 
+export type McpOAuth = z.infer<typeof mcpOAuthSchema>;
 export type McpServer = z.infer<typeof mcpServerSchema>;
 export type Permissions = z.infer<typeof permissionsSchema>;
 export type ToolConfig = z.infer<typeof toolConfigSchema>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -9,6 +9,7 @@ import type {
 
 export type {
   Config,
+  McpOAuth,
   McpServer,
   Permissions,
   RuleFrontmatter,

--- a/packages/core/src/utils/mcp.test.ts
+++ b/packages/core/src/utils/mcp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { validateMcpServers } from "./mcp";
+import { validateMcpServers, validateOAuthFieldSupport } from "./mcp";
 
 describe("validateMcpServers", () => {
   const pathPrefix = ["settings", "mcpServers"];
@@ -147,5 +147,94 @@ describe("validateMcpServers", () => {
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]?.path).toEqual(["custom", "path", "badServer"]);
+  });
+});
+
+describe("validateOAuthFieldSupport", () => {
+  const pathPrefix = ["settings", "mcpServers"];
+
+  it("returns empty array for undefined mcpServers", () => {
+    const warnings = validateOAuthFieldSupport(
+      undefined,
+      pathPrefix,
+      "Cursor",
+      ["callbackPort"]
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns empty array when no server has oauth configured", () => {
+    const warnings = validateOAuthFieldSupport(
+      { myServer: { command: "npx" } },
+      pathPrefix,
+      "Cursor",
+      ["callbackPort"]
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns empty array when the configured oauth fields are all supported", () => {
+    const warnings = validateOAuthFieldSupport(
+      {
+        myServer: {
+          type: "http",
+          url: "https://example.com/mcp",
+          oauth: { clientId: "abc" },
+        },
+      },
+      pathPrefix,
+      "Cursor",
+      ["callbackPort"]
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("warns about a single unsupported field", () => {
+    const warnings = validateOAuthFieldSupport(
+      {
+        myServer: {
+          type: "http",
+          url: "https://example.com/mcp",
+          oauth: { clientId: "abc", callbackPort: 8080 },
+        },
+      },
+      pathPrefix,
+      "Cursor",
+      ["callbackPort"]
+    );
+
+    expect(warnings).toEqual([
+      {
+        path: ["settings", "mcpServers", "myServer", "oauth"],
+        message:
+          'MCP server "myServer" has OAuth callbackPort configured - Cursor does not support syncing this field, so it will be skipped',
+      },
+    ]);
+  });
+
+  it("warns about multiple unsupported fields", () => {
+    const warnings = validateOAuthFieldSupport(
+      {
+        myServer: {
+          type: "http",
+          url: "https://example.com/mcp",
+          oauth: { clientId: "abc", clientSecret: "shh", scopes: ["read"] },
+        },
+      },
+      pathPrefix,
+      "GitHub Copilot",
+      ["clientSecret", "scopes"]
+    );
+
+    expect(warnings).toEqual([
+      {
+        path: ["settings", "mcpServers", "myServer", "oauth"],
+        message:
+          'MCP server "myServer" has OAuth clientSecret, scopes configured - GitHub Copilot does not support syncing these fields, so they will be skipped',
+      },
+    ]);
   });
 });

--- a/packages/core/src/utils/mcp.ts
+++ b/packages/core/src/utils/mcp.ts
@@ -1,4 +1,8 @@
-import type { McpServer, ValidationWarningDetail } from "../types/index";
+import type {
+  McpOAuth,
+  McpServer,
+  ValidationWarningDetail,
+} from "../types/index";
 
 /**
  * Validate MCP servers and return warnings for invalid configurations.
@@ -34,6 +38,52 @@ export function validateMcpServers(
       warnings.push({
         path: [...pathPrefix, name],
         message: `MCP server "${name}" is remote but has no URL - it will be skipped`,
+      });
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Warn about individual OAuth fields that a tool's native MCP format doesn't
+ * support, for MCP servers that have `oauth` configured. Each tool that
+ * supports OAuth supports a different subset of fields (e.g. Copilot has no
+ * `clientSecret`/`scopes`, Cursor and OpenCode have no `callbackPort`), so
+ * unsupported fields are dropped during transform and reported here rather
+ * than treating OAuth as all-or-nothing.
+ *
+ * @param mcpServers - Record of MCP server configurations
+ * @param pathPrefix - Path prefix for warning details (e.g., ["settings", "mcpServers"])
+ * @param toolName - Display name of the tool being validated (e.g., "Cursor")
+ * @param unsupportedFields - OAuth fields this tool's format doesn't support
+ * @returns Array of validation warnings for servers with unsupported OAuth fields configured
+ */
+export function validateOAuthFieldSupport(
+  mcpServers: Record<string, McpServer> | undefined,
+  pathPrefix: string[],
+  toolName: string,
+  unsupportedFields: Array<keyof McpOAuth>
+): ValidationWarningDetail[] {
+  const warnings: ValidationWarningDetail[] = [];
+
+  if (!mcpServers) {
+    return warnings;
+  }
+
+  for (const [name, server] of Object.entries(mcpServers)) {
+    if (!server.oauth) {
+      continue;
+    }
+
+    const dropped = unsupportedFields.filter(
+      (field) => server.oauth?.[field] !== undefined
+    );
+
+    if (dropped.length > 0) {
+      warnings.push({
+        path: [...pathPrefix, name, "oauth"],
+        message: `MCP server "${name}" has OAuth ${dropped.join(", ")} configured - ${toolName} does not support syncing ${dropped.length > 1 ? "these fields" : "this field"}, so ${dropped.length > 1 ? "they" : "it"} will be skipped`,
       });
     }
   }


### PR DESCRIPTION
Adds an `oauth` field (clientId, clientSecret, callbackPort, scopes) to the MCP server schema and syncs it into each tool's native format, mapping to whatever subset of fields that tool actually supports

- Verified against each tool's real docs/schema.
- Unsupported fields are dropped with a validation warning naming the field and tool, rather than silently disappearing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added static OAuth configuration for remote MCP servers, including client credentials, scopes, and callback ports.
  * Added OAuth support when exporting configurations to Claude Code, Codex, Copilot, Cursor, Gemini CLI, and OpenCode.
  * Added validation warnings for unsupported OAuth fields and conflicting callback ports.

* **Documentation**
  * Documented OAuth configuration and tool-specific field support, transformations, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->